### PR TITLE
Fix typo in terminal.go

### DIFF
--- a/core/terminal.go
+++ b/core/terminal.go
@@ -367,7 +367,7 @@ func (t *Terminal) handlePhishlets(args []string) error {
 			}
 			domain, _ := t.cfg.GetSiteDomain(args[1])
 			if domain == "" {
-				return fmt.Errorf("you need to set hostname for phishlet '%s', first. type: phishlet hostname %s your.hostame.domain.com", args[1], args[1])
+				return fmt.Errorf("you need to set hostname for phishlet '%s', first. type: phishlets hostname %s your.hostame.domain.com", args[1], args[1])
 			}
 			err = t.cfg.SetSiteEnabled(args[1])
 			if err != nil {


### PR DESCRIPTION
Fix the following typo:
```
[06:37:07] [err] phishlets: you need to set hostname for phishlet '<phishlet>', first. type: phishlet hostname <phishlet> your.hostame.domain.com
: phishlet hostname <phishlet> <hostname>
[06:37:18] [err] unknown command: phishlet
```

From: `phishlet`
To: `phishlets`