### PR TITLE
Update Dockerfile to support 2.3.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,6 @@ RUN apk add --update \
     git \
   && rm -rf /var/cache/apk/*
 
-RUN wget -O /usr/local/bin/dep https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64 && chmod +x /usr/local/bin/dep
-
 WORKDIR /go/src/github.com/kgretzky/evilginx2
 
 COPY . /go/src/github.com/kgretzky/evilginx2

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,6 @@ RUN wget -O /usr/local/bin/dep https://github.com/golang/dep/releases/download/v
 
 WORKDIR /go/src/github.com/kgretzky/evilginx2
 
-COPY Gopkg.toml Gopkg.lock ./
-
-RUN dep ensure -vendor-only
-
 COPY . /go/src/github.com/kgretzky/evilginx2
 
 RUN go build -o ./bin/evilginx main.go


### PR DESCRIPTION
atm docker fails to build the container due to missing `Gopkg.toml` file.