### PR TITLE
Update README.md to mention requirement of Go version 1.14.0 or later.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Evilginx runs very well on the most basic Debian 8 VPS.
 
 #### Installing from source
 
-In order to compile from source, make sure you have installed **GO** of version at least **1.10.0** (get it from [here](https://golang.org/doc/install)) and that `$GOPATH` environment variable is set up properly (def. `$HOME/go`).
+In order to compile from source, make sure you have installed **GO** of version at least **1.14.0** (get it from [here](https://golang.org/doc/install)) and that `$GOPATH` environment variable is set up properly (def. `$HOME/go`).
 
 After installation, add this to your `~/.profile`, assuming that you installed **GO** in `/usr/local/go`:
 


### PR DESCRIPTION
I attempted to perform an installation from source from the `master`
branch of the repository, but encountered several problems that were
only resolvable after upgrading my Go installation. The root cause was
lack of support for `go build`'s `-mod` option, as can be seen in the
following example output:

```sh
$ make
flag provided but not defined: -mod
usage: build [-o output] [-i] [build flags] [packages]
Run 'go help build' for details.
Makefile:8: recipe for target 'build' failed
make: *** [build] Error 2
```

I'm not a Go expert so I'm unsure of Golang version 1.14.0 is the
minimum required version, but I do know that this version builds
correctly. I was previously using Golang version 1.10.0, following the
README's instructions. These instructions have since become outdated,
requiring at least a documentation fix. That fix is in this patch.