### PR TITLE
Update certs.go  | ADFS fix

### DIFF
--- a/vendor/github.com/elazarl/goproxy/certs.go
+++ b/vendor/github.com/elazarl/goproxy/certs.go
@@ -15,9 +15,10 @@ func init() {
 	}
 }
 
-var tlsClientSkipVerify = &tls.Config{InsecureSkipVerify: true}
+var tlsClientSkipVerify = &tls.Config{InsecureSkipVerify: true, Renegotiation: tls.RenegotiateOnceAsClient}
 
 var defaultTLSConfig = &tls.Config{
+	Renegotiation: tls.RenegotiateOnceAsClient,
 	InsecureSkipVerify: true,
 }
 


### PR DESCRIPTION
These added lines fix the ADFS issue as reported by multiple people.
You no longer receive the mitm error message when being redirected to the ADFS sub-domain