### PR TITLE
Remove `Public-Key-Pins` related headers

### DIFF
--- a/core/http_proxy.go
+++ b/core/http_proxy.go
@@ -619,6 +619,8 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 			var rm_headers = []string{
 				"Content-Security-Policy",
 				"Content-Security-Policy-Report-Only",
+				"Public-Key-Pins",
+				"Public-Key-Pins-Report-Only",
 				"Strict-Transport-Security",
 				"X-XSS-Protection",
 				"X-Content-Type-Options",


### PR DESCRIPTION
While deprecated, it may be good practice to remove these headers to help prevent any reported violations.