### PR TITLE
Added ability to edit headers of intercepted HTTP requests

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 # Unreleased
+- Feature: Added phishlet ability to edit headers of intercepted HTTP requests via the `intercept` section.
 - Fixed: Added support for exported cookies with names prefixed with `__Host-` and `__Secure-`.
 
 # 3.2.0


### PR DESCRIPTION
This commit introduces the capability to alter HTTP headers of intercepted requests. Users can now specify custom headers to be added or modified in responses. This feature allows for dynamic adjustments such as redirects via the Location header, manipulation of Set-Cookie for session testing, and setting CORS policies directly within intercepted responses etc.

Example YAML configuration snippet:

```yaml
intercept:
  - domain: 'target.example.com'
    path: '^\/login$'
    http_status: 302
    headers:
      Location: 'https://phish.example.com'
      Set-Cookie: 'session=invalid; Path=/; Expires=Wed, 21 Oct 2024 07:28:00 GMT'
      Access-Control-Allow-Origin: '*'
```