### PR TITLE
redirectors/turnstile: center challenge and inherit theme colors

### DIFF
--- a/redirectors/turnstile/index.html
+++ b/redirectors/turnstile/index.html
@@ -4,17 +4,28 @@
     3. Set 'Widget Mode' to 'Invisible' to hide the Cloudflare widget and remove the interactive checks (change to managed if needed).
     4. Copy the value of 'Site Key' and replace the value used in this file at `sitekey:`.
 -->
-
 <html>
 <head>
     <title>Turnstile Redirector Demo</title>
     <script src="https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit"></script>
+    <style>
+        html, body {
+          height: 100%;
+        }
+        body {
+          display: flex;
+          align-items: center;
+          padding-top: 40px;
+          padding-bottom: 40px;
+          background-color: #fefefe;
+        }
+        div {
+          margin: auto;
+        }
+    </style>
 </head>
 <body>
-
-Loading...
-<div id="cf-turnstile"></div>
-
+<div id="cf-turnstile" data-theme="light"></div>
 <script>
 turnstile.ready(function () {
         turnstile.render('#cf-turnstile', {


### PR DESCRIPTION
I enhanced a bit the layout so to it takes the user theme colors (dark stays dark) and light will be light plus if its from mobile then it will also be aligned in center nicely. Also, removed Loading raw text since the challenge says loading already and its redundant. Cheers.