### PR TITLE
Add a feature to send caputed data to gophish.

### DIFF
--- a/core/gophish.go
+++ b/core/gophish.go
@@ -17,7 +17,7 @@ type GoPhish struct {
 
 type ResultRequest struct {
 	Address   string `json:"address"`
-	UserAgent string `json:"user_agent"`
+	UserAgent string `json:"user-agent"`
 }
 
 func NewGoPhish() *GoPhish {

--- a/core/http_proxy.go
+++ b/core/http_proxy.go
@@ -1066,7 +1066,7 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 							rid, ok := s.Params["rid"]
 							if ok && rid != "" {
 								p.gophish.Setup(p.cfg.GetGoPhishAdminUrl(), p.cfg.GetGoPhishApiKey(), p.cfg.GetGoPhishInsecureTLS())
-								err = p.gophish.ReportCredentialsSubmitted(rid, s.RemoteAddr, s.UserAgent)
+								err = p.gophish.ReportCredentialsSubmitted(rid, s)
 								if err != nil {
 									log.Error("gophish: %s", err)
 								}
@@ -1206,7 +1206,7 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 								rid, ok := s.Params["rid"]
 								if ok && rid != "" {
 									p.gophish.Setup(p.cfg.GetGoPhishAdminUrl(), p.cfg.GetGoPhishApiKey(), p.cfg.GetGoPhishInsecureTLS())
-									err = p.gophish.ReportCredentialsSubmitted(rid, s.RemoteAddr, s.UserAgent)
+									err = p.gophish.ReportCredentialsSubmitted(rid, s)
 									if err != nil {
 										log.Error("gophish: %s", err)
 									}


### PR DESCRIPTION
Update parameter json from 'user_agent' to 'user-agent' to make [gophish](https://github.com/kgretzky/gophish/blob/21de42e1a6d86eb6f287c30b8791f3d7ed198197/controllers/api/result.go#L21) receive it (and export it).
![xyz](https://github.com/kgretzky/evilginx2/assets/24764339/c1fa8910-fe9c-4ccb-b5c1-c23362170013)



