### PR TITLE
toolchain not available error while compiling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kgretzky/evilginx2
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/caddyserver/certmagic v0.20.0


### PR DESCRIPTION
"go 1.22" gives error when compiling the program:

```
go: downloading go1.22 (linux/amd64)
go: download go1.22 for linux/amd64: toolchain not available
make: *** [Makefile:8: build] Error 1
```