### PR TITLE
fixed: handle all optional cookies for given domain

### DIFF
--- a/core/session.go
+++ b/core/session.go
@@ -93,9 +93,11 @@ func (s *Session) AddCookieAuthToken(domain string, key string, value string, pa
 func (s *Session) AllCookieAuthTokensCaptured(authTokens map[string][]*CookieAuthToken) bool {
 	tcopy := make(map[string][]CookieAuthToken)
 	for k, v := range authTokens {
-		tcopy[k] = []CookieAuthToken{}
 		for _, at := range v {
 			if !at.optional {
+				if _, ok := tcopy[k]; !ok {
+					tcopy[k] = []CookieAuthToken{}
+				}
 				tcopy[k] = append(tcopy[k], *at)
 			}
 		}


### PR DESCRIPTION
This quick fix makes it possible, **in the absence of authorization URL**, to mark all cookie tokens as optional for a given `domain` while having other mandatory tokens, that is http or body tokens, or even non-optional cookie tokens for another `domain`.

Code analysis:

In the edge case where all cookie tokens are optional and no authorization URL is provided, Evilginx will indeed never consider the session as finished since `AllCookieAuthTokensCaptured` will always return `false`. This is because the `tcopy` array will contain from the start (first `for`) an empty array which will never be deleted (second `for`). In the absence of authorization URL, Evilginx currently stores sessions in the database only if this function returns `true` at some point, which means in this case, sessions will not be displayed even though all mandatory tokens have been captured.

Example:
```
auth_tokens:
  - domain: 'akira.lab.evilginx.com'
    keys: ['token:opt']
    type: 'cookie'
  - domain: 'akira.lab.evilginx.com'
    path: '/me'
    name: 'name'
    search: '"name":"(.*)",'
    type: 'body'
```

Without the fix:
<img width="1314" alt="image" src="https://github.com/user-attachments/assets/66ba68ec-c0da-4f65-aef9-424df23422d9" /><br><br>

With the fix:
<img width="1299" alt="image" src="https://github.com/user-attachments/assets/05051629-50cd-4aad-b255-47cfbc9f0e0b" /><br><br>

NB: In this case, the optional cookie is delivered **before** the (mandatory) body token, which is why we see it displayed in the session information. If it had been delivered **after** the body token, it wouldn't have been displayed at all:

```
auth_tokens:
  - domain: 'akira.lab.evilginx.com'
    keys: ['token:opt']
    type: 'cookie'
  - domain: 'akira.lab.evilginx.com'
    path: '/login'
    name: 'ticket'
    search: '"ticket":"([^"]*)"'
    type: 'body'
```

<img width="948" alt="image" src="https://github.com/user-attachments/assets/dfece434-bf67-4051-b6cb-b9d483ea1865" /><br><br>

In this last case, the only way to capture the optional cookie is to use an authorization URL.