### PR TITLE
fix(security): ensure redirector path containment

### DIFF
--- a/core/http_proxy.go
+++ b/core/http_proxy.go
@@ -551,6 +551,16 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 							}
 
 							path := filepath.Join(t_dir, rel_path)
+
+							// ensure we do not walk out of the redirectors directory
+							abs, err1 := filepath.Abs(path)
+							base, err2 := filepath.Abs(t_dir)
+							if err1 != nil || err2 != nil ||
+								(abs != base && !strings.HasPrefix(abs, base+string(os.PathSeparator))) {
+								log.Warning("lure: redirector path escapes redirectors dir, refusing: %s", req_path)
+								return p.blockRequest(req)
+							}
+	
 							if _, err := os.Stat(path); !os.IsNotExist(err) {
 								fdata, err := ioutil.ReadFile(path)
 								if err == nil {


### PR DESCRIPTION
This PR introduces a check to ensure a requestor cannot "walk out" of the template path when a redirector template is served, preventing file traversal/arbitrary file read. 

Currently, it is possible to traverse out of the redirector path after a session is established and read arbitrary files. Pre-requisites for this vulnerability: 
- operator has configured at least one lure with a redirector configured (`lures edit <id> redirector <name>`)
- attacker knows redirector-enabled lure URL path 

### Exploit Path 
- attacker visits the lure path once to (a) obtain a session cookie and (b) arm `s.RedirectorName` on that session, then sends a second request on the same session whose path contains `../` (URL-encoded) followed by an absolute target path.
- evilginx joins that attacker path under the redirectors directory (`filepath.Join(t_dir, rel_path)`) with no containment check so `filepath.Clean` walks out of the directory and any file the evilginx process can read is returned in the response body, unauthenticated.
- As evilginx is commonly run as root, potential impact can be much higher, but even running as unprivileged user it is possible to steal operator loot, i.e. 
  - make exploit request to `/proc/self/environ` and `/proc/self/cmdline` to ascertain config directory (default or user specified)
  - make exploit request to `<configpath>/data.db` (default: `$HOME/.evilginx/data.db`). 

### PoC 

```bash
export EVILGINX_IP=<evilginx_ip>
export HOST=<lure_host> 
export LURE=/<lure_path>

# first request to lure path to arm redirectorname 
curl -ksS --http1.1 -c jar.txt \
  --resolve "$HOST:443:$EVILGINX_IP" \
  "https://$HOST$LURE" -o /dev/null

# path traversal request to get arbitrary file 
DOTS=$(printf '%%2e%%2e%%2f%.0s' $(seq 1 12))
curl -ksS --http1.1 -b jar.txt --path-as-is \
  --resolve "$HOST:443:$EVILGINX_IP" \
  "https://$HOST$LURE/${DOTS}etc/passwd"
```

### Fix 

Implement a containment check after `filepath.Join(t_dir, rel_path)` to ensure we do not walk out of the redirector template path. In this case, rejecting the request if the requested file is outside of that boundary: 

```go
	path := filepath.Join(t_dir, rel_path)
	// ensure we do not walk out of the redirectors directory
	abs, err1 := filepath.Abs(path)
	base, err2 := filepath.Abs(t_dir)
	if err1 != nil || err2 != nil ||
		(abs != base && !strings.HasPrefix(abs, base+string(os.PathSeparator))) {
		log.Warning("lure: redirector path escapes redirectors dir, refusing: %s", req_path)
		return p.blockRequest(req)
	}
```


